### PR TITLE
simplify bootstrap profiles to only point at single upstream project; this will ensure no duplicate GAVs when building the whole stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,6 @@
 			<id>bootstrap</id>
 			<modules>
 				<module>../portlet</module>
-				<module>../javaee</module>
-				<module>../server</module>
-				<module>../jst</module>
-				<module>../vpe</module>
-				<module>../xulrunner</module>
-				<module>../base</module>
 			</modules>
 		</profile>
 	</profiles>


### PR DESCRIPTION
...is will ensure no duplicate GAVs when building the whole stack
