### PR TITLE
JBIDE-12955 fix relativeparent path

### DIFF
--- a/central/pom.xml
+++ b/central/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>central</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>examples</artifactId>

--- a/maven/plugins/pom.xml
+++ b/maven/plugins/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>maven</artifactId>
 		<version>1.4.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jboss.tools.maven</groupId>
 	<artifactId>plugins</artifactId>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>maven</artifactId>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/jboss-sar/parent/ear/pom.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/jboss-sar/parent/ear/pom.xml
@@ -5,7 +5,6 @@
 		<groupId>org.jboss.tools.maven.tests</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jboss.tools.maven.tests</groupId>
 	<artifactId>ear</artifactId>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/jboss-sar/parent/sar/pom.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/jboss-sar/parent/sar/pom.xml
@@ -5,7 +5,6 @@
 		<groupId>org.jboss.tools.maven.tests</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>sar</artifactId>
 	<packaging>jboss-sar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>central.maven.examples</artifactId>


### PR DESCRIPTION
I suggest we don't use the root of "uber" components as the parent since components like central would overlap in naming and maven in central is not really a child of central. WDYT ?

here in central there were also two places where .. on its own was used which afaik is the default thus redundant. I included this in here since related to relativePath.
