### PR TITLE
JBIDE-13128 : install CDI facet when beans.xml is detected

### DIFF
--- a/maven/plugins/org.jboss.tools.maven.cdi/src/org/jboss/tools/maven/cdi/configurators/CDIProjectConfigurator.java
+++ b/maven/plugins/org.jboss.tools.maven.cdi/src/org/jboss/tools/maven/cdi/configurators/CDIProjectConfigurator.java
@@ -11,14 +11,20 @@
 package org.jboss.tools.maven.cdi.configurators;
 
 import java.util.List;
+import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
@@ -32,8 +38,10 @@ import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.jboss.tools.cdi.core.CDICoreNature;
 import org.jboss.tools.cdi.core.CDIUtil;
+import org.jboss.tools.common.model.util.EclipseResourceUtil;
 import org.jboss.tools.maven.cdi.MavenCDIActivator;
 import org.jboss.tools.maven.core.IJBossMavenConstants;
+import org.jboss.tools.maven.core.ProjectUtil;
 import org.jboss.tools.maven.core.internal.project.facet.MavenFacetInstallDataModelProvider;
 import org.jboss.tools.maven.ui.Activator;
 
@@ -91,7 +99,7 @@ public class CDIProjectConfigurator extends AbstractProjectConfigurator {
 			return;
 		}
 		String packaging = mavenProject.getPackaging();
-	    String cdiVersion = getCDIVersion(mavenProject);
+	    String cdiVersion = getCDIVersion(project, mavenProject);
 	    if (cdiVersion != null) {
 	    	if ( (fproj != null) && ("war".equals(packaging) || "ejb".equals(packaging)) ) { //$NON-NLS-1$
 	    		installDefaultFacets(fproj, cdiVersion, monitor);
@@ -173,10 +181,13 @@ public class CDIProjectConfigurator extends AbstractProjectConfigurator {
 		return versionString;
 	}
 	
-	private String getCDIVersion(MavenProject mavenProject) {
+	private String getCDIVersion(IProject project, MavenProject mavenProject) throws CoreException {
 		String version = Activator.getDefault().getDependencyVersion(mavenProject, CDI_API_GROUP_ID, CDI_API_ARTIFACT_ID);
 		if (version == null) {
 			version = inferCdiVersionFromDependencies(mavenProject);
+		}
+		if (version == null) {
+			version = (hasBeansXml(project))?DEFAULT_CDI_VERSION:null;
 		}
 	    return version;
 	}
@@ -206,8 +217,26 @@ public class CDIProjectConfigurator extends AbstractProjectConfigurator {
 		return (artifact.getGroupId().startsWith("org.jboss.seam.") 
 			&& artifact.getVersion().startsWith("3."))
 			|| artifact.getGroupId().startsWith("org.apache.deltaspike.");
-		
-		
 	}
 
+	private boolean hasBeansXml(IProject project) throws CoreException {
+		IFacetedProject facetedProject = ProjectFacetsManager.create(project);
+		if(facetedProject!=null && facetedProject.hasProjectFacet(dynamicWebFacet)) {
+			IFile beansXml = ProjectUtil.getWebResourceFile(project, "WEB-INF/beans.xml");
+			if (beansXml != null && beansXml.exists()) {
+				return true;
+			}
+		} 
+		if(project.hasNature(JavaCore.NATURE_ID)) {
+			Set<IFolder> sources = EclipseResourceUtil.getSourceFolders(project);
+			IPath beansPath = new Path("META-INF/beans.xml");
+			for (IFolder src : sources) {
+				IFile beansXml = src.getFile(beansPath);
+				if(beansXml!=null && beansXml.exists()) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}	
 }

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/jar-has-beans-xml/pom.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/jar-has-beans-xml/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>jar-has-beans-xml</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<dependencies>
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-web-api</artifactId>
+			<version>6.0</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/jar-has-beans-xml/src/main/resources/META-INF/beans.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/jar-has-beans-xml/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-beans-xml/pom.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-beans-xml/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>war-has-beans-xml</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>war</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-web-api</artifactId>
+			<version>6.0</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+	<build>
+	<plugins>
+	<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+	</plugins>
+	</build>
+</project>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-beans-xml/src/main/webapp/WEB-INF/beans.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-beans-xml/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-metainfbeans-xml/pom.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-metainfbeans-xml/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>war-has-metainfbeans-xml</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>war</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-web-api</artifactId>
+			<version>6.0</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+	<build>
+	<plugins>
+	<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+	</plugins>
+	</build>
+</project>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-metainfbeans-xml/src/main/resources/META-INF/beans.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-has-metainfbeans-xml/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-no-cdi/pom.xml
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/projects/cdi/war-no-cdi/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>war-no-cdi</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>war</packaging>
+	<build>
+	<plugins>
+	<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+	</plugins>
+	</build>
+</project>

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/src/org/jboss/tools/maven/configurators/tests/CDIConfiguratorTest.java
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/src/org/jboss/tools/maven/configurators/tests/CDIConfiguratorTest.java
@@ -27,16 +27,44 @@ public class CDIConfiguratorTest extends AbstractMavenConfiguratorTest {
 	
 	@Test
 	public void testJBIDE11741_deltaSpikeDependency() throws Exception {
-		String projectLocation = "projects/cdi/deltaspike";
-		IProject cdiProject = importProject(projectLocation+"/pom.xml");
-		waitForJobsToComplete();
-		assertNoErrors(cdiProject);
-		assertIsCDIProject(cdiProject, DEFAULT_CDI_VERSION);
+		testCdiProject("deltaspike");
 	}
 
 	@Test
 	public void testJBIDE12558_unsupportedCdiVersion() throws Exception {
-		String projectLocation = "projects/cdi/unsupported-cdi-version";
+		testCdiProject("unsupported-cdi-version");
+	}
+
+	@Test
+	public void testJBIDE13128_warHasBeansXml() throws Exception {
+		testCdiProject("war-has-beans-xml");
+	}
+
+	@Test
+	public void testJBIDE13128_warHasMetaInfBeansXml() throws Exception {
+		testCdiProject("war-has-metainfbeans-xml");
+	}
+
+	@Test
+	public void testJBIDE13128_jarHasBeansXml() throws Exception {
+		testCdiProject("jar-has-beans-xml");
+	}
+
+	@Test
+	public void testJBIDE13128_warNoCdi() throws Exception {
+		String projectLocation = "projects/cdi/war-no-cdi";
+		IProject notCdiProject = importProject(projectLocation+"/pom.xml");
+		waitForJobsToComplete();
+		assertNoErrors(notCdiProject);
+		assertFalse("CDI nature should be missing", notCdiProject.hasNature(CDICoreNature.NATURE_ID));
+
+		IFacetedProject facetedProject = ProjectFacetsManager.create(notCdiProject);
+		assertNull("CDI Facet should be missing ",facetedProject.getInstalledVersion(CDI_FACET));
+	}
+
+	
+	protected void testCdiProject(String projectName) throws Exception {
+		String projectLocation = "projects/cdi/"+projectName;
 		IProject cdiProject = importProject(projectLocation+"/pom.xml");
 		waitForJobsToComplete();
 		assertNoErrors(cdiProject);


### PR DESCRIPTION
allows projects to be CDI enabled even if they don't have "known" CDI dependencies.

CDI is enabled if a web project contains <web resource folder>/WEB-INF/beans.xml or if a Java project contains <source folder>/META-INF/beans.xml
