### PR TITLE
JBIDE-13048 : disable Java EE configurators

### DIFF
--- a/maven/plugins/org.jboss.tools.maven.jaxrs/src/org/jboss/tools/maven/jaxrs/configurators/JaxrsProjectConfigurator.java
+++ b/maven/plugins/org.jboss.tools.maven.jaxrs/src/org/jboss/tools/maven/jaxrs/configurators/JaxrsProjectConfigurator.java
@@ -19,6 +19,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
@@ -86,6 +87,10 @@ public class JaxrsProjectConfigurator extends AbstractProjectConfigurator {
 	
 	private void configureInternal(MavenProject mavenProject,IProject project,
 			IProgressMonitor monitor) throws CoreException {
+		
+		if (Platform.getBundle("org.eclipse.m2e.wtp.jaxrs") != null) {
+			return;
+		}
 		
 		if(!"war".equals(mavenProject.getPackaging())) { //$NON-NLS-1$
 			return;

--- a/maven/plugins/org.jboss.tools.maven.jpa/src/org/jboss/tools/maven/jpa/configurators/JpaProjectConfigurator.java
+++ b/maven/plugins/org.jboss.tools.maven.jpa/src/org/jboss/tools/maven/jpa/configurators/JpaProjectConfigurator.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jpt.common.core.resource.ResourceLocator;
@@ -161,6 +162,9 @@ public class JpaProjectConfigurator extends AbstractProjectConfigurator {
 	}
 
 	private boolean canConfigure(IProject project) throws CoreException {
+		if (Platform.getBundle("org.eclipse.m2e.wtp.jpa") != null) {
+			return false;
+		}
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 		boolean configureJpa = store.getBoolean(Activator.CONFIGURE_JPA);
 		return configureJpa 

--- a/maven/plugins/org.jboss.tools.maven.jsf/src/org/jboss/tools/maven/jsf/configurators/JSFProjectConfigurator.java
+++ b/maven/plugins/org.jboss.tools.maven.jsf/src/org/jboss/tools/maven/jsf/configurators/JSFProjectConfigurator.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jst.j2ee.project.facet.IJ2EEFacetConstants;
 import org.eclipse.jst.jsf.core.internal.project.facet.IJSFFacetInstallDataModelProperties;
@@ -105,6 +106,10 @@ public class JSFProjectConfigurator extends AbstractProjectConfigurator {
 	
 	private void configureInternal(MavenProject mavenProject,IProject project,
 			IProgressMonitor monitor) throws CoreException {
+
+		if (Platform.getBundle("org.eclipse.m2e.wtp.jsf") != null) {
+			return;
+		}
 		
 		if (!"war".equals(mavenProject.getPackaging()))  {//$NON-NLS-1$
 			return;

--- a/maven/plugins/org.jboss.tools.maven.ui/src/org/jboss/tools/maven/ui/preferences/ConfiguratorPreferencePage.java
+++ b/maven/plugins/org.jboss.tools.maven.ui/src/org/jboss/tools/maven/ui/preferences/ConfiguratorPreferencePage.java
@@ -50,7 +50,11 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 	private static final String ORG_JBOSS_TOOLS_MAVEN_JAXRS = "org.jboss.tools.maven.jaxrs"; //$NON-NLS-1$
 	private static final String ORG_JBOSS_TOOLS_MAVEN_JPA = "org.jboss.tools.maven.jpa"; //$NON-NLS-1$
 	private static final String ORG_JBOSS_TOOLS_MAVEN_GWT = "org.jboss.tools.maven.gwt"; //$NON-NLS-1$
-	
+
+	private static final String ORG_ECLIPSE_M2E_WTP_JAXRS = "org.eclipse.m2e.wtp.jaxrs"; //$NON-NLS-1$
+	private static final String ORG_ECLIPSE_M2E_WTP_JPA = "org.eclipse.m2e.wtp.jpa"; //$NON-NLS-1$
+	private static final String ORG_ECLIPSE_M2E_WTP_JSF = "org.eclipse.m2e.wtp.jsf"; //$NON-NLS-1$
+
 	private Button configureSeamButton;
 	private Button configureSeamRuntimeButton;
 	private Button configureSeamArtifactsButton;
@@ -107,7 +111,7 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 			});
 		}
 		
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JSF) ) { 
 			configureJSFButton = new Button(composite,SWT.CHECK);
 			configureJSFButton.setText(Messages.ConfiguratorPreferencePage_Configure_JSF_facet);
 			boolean configureJSF = store.getBoolean(Activator.CONFIGURE_JSF);
@@ -151,14 +155,14 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 			configureHibernateButton.setSelection(configureHibernate);
 		}
 		
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JAXRS) ) { 
 			configureJaxRsButton = new Button(composite,SWT.CHECK);
 			configureJaxRsButton.setText(Messages.ConfiguratorPreferencePage_Configure_JAX_RS_facet);
 			boolean configureJaxRs = store.getBoolean(Activator.CONFIGURE_JAXRS);
 			configureJaxRsButton.setSelection(configureJaxRs);
 		}
 		
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JPA)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JPA) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JPA) ) { 
 			configureJpaButton = new Button(composite,SWT.CHECK);
 			configureJpaButton.setText(Messages.ConfiguratorPreferencePage_Configure_JPA_facet);
 			boolean configureJpa = store.getBoolean(Activator.CONFIGURE_JPA);
@@ -210,7 +214,7 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 
 	@Override
 	protected void performDefaults() {
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JSF) ) { 
 			configureJSFButton.setSelection(Activator.CONFIGURE_JSF_VALUE);
 			configureWebxmlJSF20Button.setSelection(Activator.CONFIGURE_WEBXML_JSF20_VALUE);
 		}
@@ -234,13 +238,17 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 			configureHibernateButton.setSelection(Activator.CONFIGURE_HIBERNATE_VALUE);
 		}
 		
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JAXRS)) { 
 			configureJaxRsButton.setSelection(Activator.CONFIGURE_JAXRS_VALUE);
+		}
+
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JPA) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JPA)) { 
+			configureJpaButton.setSelection(Activator.CONFIGURE_JPA_VALUE);
 		}
 		
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 		
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JSF)) { 
 			store.setValue(Activator.CONFIGURE_JSF, Activator.CONFIGURE_JSF_VALUE);
 		}
 		
@@ -266,11 +274,11 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 			store.setValue(Activator.CONFIGURE_HIBERNATE, Activator.CONFIGURE_HIBERNATE_VALUE);
 		}
 
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JAXRS)) { 
 			store.setValue(Activator.CONFIGURE_JAXRS, Activator.CONFIGURE_JAXRS_VALUE);
 		}
 
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JPA)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JPA) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JPA)) { 
 			store.setValue(Activator.CONFIGURE_JPA, Activator.CONFIGURE_JPA_VALUE);
 		}
 		
@@ -284,7 +292,7 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 	@Override
 	public boolean performOk() {
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF)) { 
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JSF) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JSF)) { 
 			store.setValue(Activator.CONFIGURE_JSF, configureJSFButton.getSelection());
 			store.setValue(Activator.CONFIGURE_WEBXML_JSF20, configureWebxmlJSF20Button.getSelection());
 		}
@@ -309,11 +317,11 @@ public class ConfiguratorPreferencePage extends PreferencePage implements
 			store.setValue(Activator.CONFIGURE_HIBERNATE, configureHibernateButton.getSelection());
 		}
 
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS)) {
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JAXRS) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JAXRS)) {
 			store.setValue(Activator.CONFIGURE_JAXRS, configureJaxRsButton.getSelection());
 		}
 
-		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JPA)) {
+		if (bundleExists(ORG_JBOSS_TOOLS_MAVEN_JPA) && !bundleExists(ORG_ECLIPSE_M2E_WTP_JPA)) {
 			store.setValue(Activator.CONFIGURE_JPA, configureJpaButton.getSelection());
 		}
 		


### PR DESCRIPTION
JAX-RS, JPA and JSF configurators from JBoss tools must be disabled
when the new, corresponding configurators from m2e-wtp are installed

In the long term, the m2e-wtp features can be made updateable over the
jbosstools ones. However, updating the features from JBDS will be trickier.
This solution, makes JBDS 6.0 m2e-wtp 0.17.0-ready, kinda.

This also allows us to hack the m2e-wtp configurators in a full environment
during the code migration.

Signed-off-by: Fred Bricon fbricon@gmail.com
