### PR TITLE
JBDS-2429 - NullPointerException when closing JBDS 6.0

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/JBossCentralActivator.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/JBossCentralActivator.java
@@ -372,6 +372,9 @@ public class JBossCentralActivator extends AbstractUIPlugin {
 
 	protected static JBossCentralEditor openJBossCentralEditor(
 			IWorkbenchPage page) {
+		if (!PlatformUI.isWorkbenchRunning() || PlatformUI.getWorkbench().isClosing()) {
+			return null;
+		}
 		IEditorInput input = JBossCentralEditorInput.INSTANCE;
 		try {
 			IEditorPart editor = page.openEditor(input, JBossCentralEditor.ID);


### PR DESCRIPTION
https://issues.jboss.org/browse/JBDS-2429
NullPointerException when closing JBDS 6.0 beta2
