### PR TITLE
JBIDE-14350 - Search field disappears when Central editor is too small

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
@@ -256,7 +256,8 @@ public class JBossCentralEditor extends SharedHeaderFormEditor {
 	    settingsComposite.setLayout(layout);
 	    //GridDataFactory.fillDefaults().grab(true, true).applyTo(settingsComposite);
 		
-	    final Button showOnStartup = getToolkit().createButton(settingsComposite, "Show on Startup", SWT.CHECK);
+	    final Button showOnStartup = getToolkit().createButton(settingsComposite, "", SWT.CHECK);
+	    showOnStartup.setToolTipText("Show on Startup");
 		showOnStartup.setLayoutData(new GridData(SWT.BEGINNING, SWT.TOP, false, false));
 		showOnStartup.setBackground(settingsComposite.getBackground());
 		showOnStartup.setSelection(JBossCentralActivator.getDefault().showJBossCentralOnStartup());


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-14350
Search field disappears when Central editor is too small 