### PR TITLE
JBIDE-14719 - getCurrentProject is named 'Launch Junit test'

### DIFF
--- a/examples/plugins/org.jboss.tools.project.examples.cheatsheet/plugin.xml
+++ b/examples/plugins/org.jboss.tools.project.examples.cheatsheet/plugin.xml
@@ -126,7 +126,7 @@
       -->
       <command
       		defaultHandler="org.jboss.tools.project.examples.cheatsheet.actions.GetProjectForCheatsheetHandler"
-            name="Launch JUnit tests"
+            name="Get current project"
             id="org.jboss.tools.project.examples.cheatsheet.getProjectForCheatsheet">
       </command>
    </extension>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-14719
getCurrentProject is named "Launch Junit test"
