### PR TITLE
JBIDE-15013 - Unable to load RefreshJBossBlogsHandler error in Error Log

### DIFF
--- a/central/plugins/org.jboss.tools.central/plugin.xml
+++ b/central/plugins/org.jboss.tools.central/plugin.xml
@@ -81,16 +81,7 @@
             name="Refresh"
             id="org.jboss.tools.central.refreshJBossTutorials">
       </command>
-      <command
-      		defaultHandler="org.jboss.tools.central.actions.RefreshJBossBlogsHandler"
-            name="Refresh"
-            id="org.jboss.tools.central.refreshJBossBlogs">
-      </command>
-      <command
-      		defaultHandler="org.jboss.tools.central.actions.RefreshJBossNewsHandler"
-            name="Refresh"
-            id="org.jboss.tools.central.refreshJBossNews">
-      </command>
+      
       <command
       		defaultHandler="org.jboss.tools.central.actions.RefreshJBossBuzzHandler"
             name="Refresh"
@@ -170,14 +161,6 @@
       <image
             commandId="org.jboss.tools.central.openJBossBuzz"
             icon="icons/buzz.gif">
-      </image>
-      <image
-            commandId="org.jboss.tools.central.refreshJBossBlogs"
-            icon="icons/refresh.gif">
-      </image>
-      <image
-            commandId="org.jboss.tools.central.refreshJBossNews"
-            icon="icons/refresh.gif">
       </image>
       <image
             commandId="org.jboss.tools.central.refreshJBossBuzz"


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-15013
Unable to load RefreshJBossBlogsHandler error in Error Log
https://issues.jboss.org/browse/JBIDE-14939
RefreshJBossNewsHandler class not found exception in log after JBoss Rools 4.1.0.Beta2 Installation
