### PR TITLE
JBIDE-15150 - Unable to create menu item 'org.jboss.tools.central.openJBossNews'

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedPage.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedPage.java
@@ -340,9 +340,6 @@ public class GettingStartedPage extends AbstractJBossCentralPage implements Prox
 		CommandContributionItem item = JBossCentralActivator.createContributionItem(getSite(), "org.jboss.tools.central.openJBossBuzz");
 		buzzToolBarManager.add(item);
 
-		item = JBossCentralActivator.createContributionItem(getSite(), "org.jboss.tools.central.openJBossNews");
-		buzzToolBarManager.add(item);
-
 		item = JBossCentralActivator.createContributionItem(getSite(), "org.jboss.tools.central.openJBossToolsTwitter");
 		buzzToolBarManager.add(item);
 				


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-15150
 Unable to create menu item "org.jboss.tools.central.openJBossNews", command "org.jboss.tools.central.openJBossNews" not defined '
