### PR TITLE
JBIDE-16290 - Re-enable GTK3 when running central tests

### DIFF
--- a/central/tests/org.jboss.tools.central.test/src/org/jboss/tools/central/test/CentralTest.java
+++ b/central/tests/org.jboss.tools.central.test/src/org/jboss/tools/central/test/CentralTest.java
@@ -107,10 +107,9 @@ public class CentralTest {
 		assertTrue("The Show On Startup property isn't set by default",
 				JBossCentralActivator.getDefault().showJBossCentralOnStartup());
 		new ShowJBossCentral().earlyStartup();
-		JobUtils.delay(1000);
-
 		waitForJobs();
-
+		JobUtils.delay(1000);
+		
 		assertTrue("The JBoss Central editor isn't open by default",
 				hasOpenEditor());
 		IEclipsePreferences prefs = JBossCentralActivator.getDefault()

--- a/pom.xml
+++ b/pom.xml
@@ -21,19 +21,5 @@
 		<module>central</module>
 		<module>site</module>
 	</modules>
-	<build>
-	  <plugins>
-		<plugin>
-			<groupId>org.eclipse.tycho</groupId>
-			<artifactId>tycho-surefire-plugin</artifactId>
-			<version>${tychoVersion}</version>
-			<configuration>
-				<environmentVariables>
-					<SWT_GTK3>0</SWT_GTK3>
-				</environmentVariables>
-			</configuration>
-		</plugin>
-	  </plugins>
-    </build>
 </project>
 	


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-16290
Bugs using SWT over GTK3
