### PR TITLE
JBIDE-16649 : deactivate Profile Mgmt if the m2e one is installed

### DIFF
--- a/maven/plugins/org.jboss.tools.maven.profiles.ui/META-INF/MANIFEST.MF
+++ b/maven/plugins/org.jboss.tools.maven.profiles.ui/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface.text,
  org.eclipse.jdt.ui;bundle-version="3.7.0",
  org.eclipse.jdt;bundle-version="3.7.0",
- org.jboss.tools.maven.profiles.core
+ org.jboss.tools.maven.profiles.core,
+ org.eclipse.core.expressions
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: %Bundle-Vendor

--- a/maven/plugins/org.jboss.tools.maven.profiles.ui/plugin.properties
+++ b/maven/plugins/org.jboss.tools.maven.profiles.ui/plugin.properties
@@ -2,5 +2,5 @@ Bundle-Vendor = JBoss by Red Hat
 Bundle-Name = Maven Profiles Management UI
 
 #Maven Profile selection menu
-Select_Maven_Profiles_Cmd= Select Maven Profiles
+Select_Maven_Profiles_Cmd= Maven Profiles Selection
 Select_Maven_Profiles_Menu= Select Maven Profiles...

--- a/maven/plugins/org.jboss.tools.maven.profiles.ui/plugin.xml
+++ b/maven/plugins/org.jboss.tools.maven.profiles.ui/plugin.xml
@@ -28,6 +28,18 @@
        </key>
     </extension>
    
+
+   <extension point="org.eclipse.core.expressions.propertyTesters">
+      <propertyTester
+            class="org.jboss.tools.maven.profiles.ui.internal.M2eProfilePropertyTester"
+            id="org.jboss.tools.maven.profiles.ui.internal.M2eProfilePropertyTester"
+            namespace="org.jboss.tools.maven.profiles"
+            properties="hasConflict"
+            type="java.lang.Object">
+      </propertyTester>
+   </extension>
+  
+   
    <extension point="org.eclipse.ui.popupMenus">
         <objectContribution id="org.jboss.tools.maven.ui.profiles.selectFromProject"
                           objectClass="org.eclipse.core.resources.IProject"
@@ -42,6 +54,9 @@
          <visibility>
            <and>
              <objectState name="open" value="true"/>
+             <not>
+             	<pluginState id="org.eclipse.m2e.profiles.ui" value="installed"/>
+             </not>
              <objectState name="nature" value="org.eclipse.m2e.core.maven2Nature"/>
            </and>
          </visibility>
@@ -58,7 +73,12 @@
                  menubarPath="org.eclipse.m2e.core.fileMenu/open"
                  enablesFor="+"/>
          <visibility>
+           <and>
             <objectState name="name" value="pom.xml"/>
+             <not>
+             	<pluginState id="org.eclipse.m2e.profiles.ui" value="installed"/>
+             </not>
+           </and>
          </visibility>
       </objectContribution>
       
@@ -72,6 +92,11 @@
                  definitionId="org.jboss.tools.maven.ui.commands.selectMavenProfileCommand"
                  menubarPath="org.eclipse.m2e.core.workingSetMenu/open"
                  enablesFor="+"/>
+         <visibility>
+             <not>
+             	<pluginState id="org.eclipse.m2e.profiles.ui" value="installed"/>
+             </not>
+         </visibility>
       </objectContribution>
       
   </extension> 
@@ -86,6 +111,11 @@
                    icon="icons/maven-profiles.gif"
                    id="org.jboss.tools.maven.ui.toolbars.selectMavenProfilesCommand"
                    tooltip="%Select_Maven_Profiles_Cmd">
+                   <visibleWhen>
+                      <test
+						  property="org.jboss.tools.maven.profiles.hasConflict" 
+						  value="false" forcePluginActivation="true"/> 
+                   </visibleWhen>
              </command>
           </toolbar>
        </menuContribution>

--- a/maven/plugins/org.jboss.tools.maven.profiles.ui/src/org/jboss/tools/maven/profiles/ui/internal/M2eProfilePropertyTester.java
+++ b/maven/plugins/org.jboss.tools.maven.profiles.ui/src/org/jboss/tools/maven/profiles/ui/internal/M2eProfilePropertyTester.java
@@ -1,0 +1,45 @@
+/*************************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.jboss.tools.maven.profiles.ui.internal;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.runtime.Platform;
+
+/**
+ * 
+ * @author Fred Bricon
+ * 
+ */
+public class M2eProfilePropertyTester extends PropertyTester {
+
+	
+	private static final Boolean hasConflict;
+
+	static {
+		hasConflict = Platform.getBundle("org.eclipse.m2e.profiles.ui") != null;
+	}
+	
+	@Override
+	public boolean test(Object receiver, String property, Object[] args,
+			Object expectedValue) {
+		if (!"hasConflict".equals(property)) {
+			return false;
+		} 
+		
+		return hasConflict.equals(expectedValue);
+	}
+	
+	public static boolean isConflicting() {
+		return hasConflict.booleanValue();
+	}
+	
+		
+}


### PR DESCRIPTION
Rather than preventing m2e 1.5 from being installed with this version of the Maven Profile Manager,
we detect if the conflicted plugin is installed and hide the menus, icons and remove the key binding to Ctrl-Alt-P so both Managers can coexist without any conflict

Signed-off-by: Fred Bricon fbricon@gmail.com
