### PR TITLE
JBIDE-16574 : make m2eclipse-egit an optional required import O_o

### DIFF
--- a/maven/features/org.jboss.tools.maven.cdi.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.cdi.feature/feature.xml
@@ -19,10 +19,11 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.feature" version="0.16.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.wtp.feature" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.tools.maven.feature" version="1.6.0" match="greaterOrEqual"/>
    </requires>
-   
+
    <plugin
          id="org.jboss.tools.maven.cdi"
          download-size="0"

--- a/maven/features/org.jboss.tools.maven.feature/build.properties
+++ b/maven/features/org.jboss.tools.maven.feature/build.properties
@@ -1,3 +1,4 @@
 bin.includes = feature.xml,\
                license.html,\
-               feature.properties
+               feature.properties,\
+               p2.inf

--- a/maven/features/org.jboss.tools.maven.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.feature/feature.xml
@@ -19,9 +19,14 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.feature" version="0.16.0" match="greaterOrEqual"/>
-    </requires>
+      <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.wtp.feature" version="1.1.0" match="greaterOrEqual"/>
+
+      <!-- JBIDE-16574 : force m2eclipse-egit to be installed if available
+           Since it's not a real build requirement, we make it optional by tweaking p2.inf
+      -->
+      <import feature="org.sonatype.m2e.egit.feature" version="0.14.0" match="greaterOrEqual"/>
+   </requires>
 
    <plugin
          id="org.jboss.tools.maven.core"
@@ -42,6 +47,6 @@
          download-size="0"
          install-size="0"
          version="0.0.0"
-         unpack="false"/>         
-         
+         unpack="false"/>
+
 </feature>

--- a/maven/features/org.jboss.tools.maven.feature/p2.inf
+++ b/maven/features/org.jboss.tools.maven.feature/p2.inf
@@ -1,0 +1,5 @@
+requires.2.namespace=org.eclipse.equinox.p2.iu
+requires.2.name=org.sonatype.m2e.egit.feature.feature.group
+requires.2.range=0.14.0
+requires.2.optional=true
+requires.2.greedy=true

--- a/maven/features/org.jboss.tools.maven.hibernate.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.hibernate.feature/feature.xml
@@ -19,8 +19,10 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.tools.maven.feature" version="1.6.0" match="greaterOrEqual"/>
    </requires>
+
 
    <plugin
          id="org.jboss.tools.maven.hibernate"

--- a/maven/features/org.jboss.tools.maven.jbosspackaging.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.jbosspackaging.feature/feature.xml
@@ -19,9 +19,10 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.feature" version="0.16.0" match="greaterOrEqual"/>
-      <import feature="org.jboss.ide.eclipse.as.feature" version="2.3.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.wtp.feature" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.tools.maven.feature" version="1.6.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.ide.eclipse.as.feature" version="3.0.0" match="greaterOrEqual"/>
    </requires>
    
    <plugin

--- a/maven/features/org.jboss.tools.maven.portlet.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.portlet.feature/feature.xml
@@ -19,8 +19,9 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.feature" version="0.16.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.wtp.feature" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.tools.maven.feature" version="1.6.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/maven/features/org.jboss.tools.maven.project.examples.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.project.examples.feature/feature.xml
@@ -19,12 +19,13 @@
    </license>
 
    <requires>
- 	<import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
-	<import feature="org.eclipse.m2e.wtp.feature" version="0.16.0" match="greaterOrEqual"/>
+ 	<import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+	<import feature="org.eclipse.m2e.wtp.feature" version="1.1.0" match="greaterOrEqual"/>
+   <import feature="org.jboss.tools.maven.feature" version="1.6.0" match="greaterOrEqual"/>
   	<import feature="org.jboss.tools.project.examples.feature" version="1.4.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.jsf.feature" version="0.17.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.jaxrs.feature" version="0.17.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.jpa.feature" version="0.17.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.m2e.wtp.jsf.feature" version="1.1.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.m2e.wtp.jaxrs.feature" version="1.1.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.m2e.wtp.jpa.feature" version="1.1.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/maven/features/org.jboss.tools.maven.seam.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.seam.feature/feature.xml
@@ -19,8 +19,9 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.wtp.feature" version="0.16.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.wtp.feature" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.tools.maven.feature" version="1.6.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/maven/features/org.jboss.tools.maven.sourcelookup.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.sourcelookup.feature/feature.xml
@@ -19,7 +19,8 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.m2e.feature" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.tools.maven.feature" version="1.6.0" match="greaterOrEqual"/>
    </requires>
    
    <plugin

--- a/maven/features/org.jboss.tools.maven.test.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.test.feature/feature.xml
@@ -17,4 +17,10 @@
 	<plugin id="org.jboss.tools.maven.configurators.tests" download-size="0" install-size="0" version="0.0.0" />
 	<plugin id="org.jboss.tools.maven.conversion.test" download-size="0" install-size="0" version="0.0.0" />
 	<plugin id="org.jboss.tools.maven.sourcelookup.test" download-size="0" install-size="0" version="0.0.0" />
+
+  <!-- JBIDE-17019 ; make sure m2eclipse-egit is available in TP -->
+   <requires>
+      <import feature="org.sonatype.m2e.egit.feature" version="0.14.0" match="greaterOrEqual"/>
+   </requires>
+  
 </feature>


### PR DESCRIPTION
Using p2.inf black magic to make m2eclipse-egit required import optional in org.jboss.tools.maven.feature.

Also made all other jboss maven features depend on org.jboss.tools.maven.feature, so that m2eclipse-egit is installed whenever one of these is installed.

https://issues.jboss.org/browse/JBIDE-16574

Signed-off-by: Fred Bricon fbricon@gmail.com
