### PR TITLE
[JBIDE-17599] Revert 'installed' check box label in JBoss Central Update tab

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/DiscoveryViewer.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/DiscoveryViewer.java
@@ -516,7 +516,7 @@ public class DiscoveryViewer extends Viewer {
 				if (this.userFilters.size() == 1) {
 					final UserFilterEntry theFilter = this.userFilters.get(0);
 					final Button checkbox = new Button(filterContainer, SWT.CHECK);
-					checkbox.setSelection(theFilter.isEnabled());
+					checkbox.setSelection(!theFilter.isEnabled());
 					checkbox.setText(theFilter.getLabel());
 					checkbox.addSelectionListener(new SelectionListener() {
 						public void widgetDefaultSelected(SelectionEvent e) {
@@ -524,7 +524,7 @@ public class DiscoveryViewer extends Viewer {
 						}
 
 						public void widgetSelected(SelectionEvent e) {
-							theFilter.setEnabled(checkbox.getSelection());
+							theFilter.setEnabled(!checkbox.getSelection());
 							updateFilters();
 						}
 					});

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/messages.properties
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/messages.properties
@@ -1,7 +1,7 @@
 DiscoveryViewer_Certification_Label0=by {0}, {1}, <a>{2}</a>
 DiscoveryViewer_X_installed={0} (INSTALLED - {1})
 
-DiscoveryViewer_Hide_installed = Hide installed
+DiscoveryViewer_Hide_installed = Show installed
 DiscoveryViewer_Enable_EarlyAccess=Enable Early-Access
 DiscoveryViewer_Show_only_most_recent = Show only most recent version of connector
 


### PR DESCRIPTION
Inverted checkbox from Hide to Show. For details see
https://issues.jboss.org/browse/JBIDE-17538.
