### PR TITLE
JBIDE-18247 : delay remote variable resolution to when necessary

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/internal/discovery/wizards/ProxyWizardManager.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/internal/discovery/wizards/ProxyWizardManager.java
@@ -56,7 +56,6 @@ public class ProxyWizardManager {
 	private ProxyWizardManager() {
 		updateJob = new ProxyWizardUpdateJob(this);
 		//Use -Djboss.discovery.directory.url=... to override the discovery url value
-		discoveryUrl = ProjectExamplesActivator.getDefault().getConfigurator().getJBossDiscoveryDirectory(); 
 	}
 
 	/**
@@ -147,6 +146,9 @@ public class ProxyWizardManager {
 	}
 
 	String getDiscoveryUrl() {
+		if (discoveryUrl == null) {
+			discoveryUrl = ProjectExamplesActivator.getDefault().getConfigurator().getJBossDiscoveryDirectory(); 
+		}
 		return discoveryUrl;
 	}
 

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/jobs/AbstractRefreshJob.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/jobs/AbstractRefreshJob.java
@@ -58,9 +58,20 @@ public abstract class AbstractRefreshJob extends Job {
 	private boolean forcedDownload = false;
 	private boolean needsRefresh = true;
 
+	/**
+	 * Subclasses are expected to provide the urlString via the {@link #getUrlString()} method.
+	 * 
+	 * @param name the name of the Job
+	 * @param urlString the url to fetch data from
+	 */
+	@Deprecated
 	public AbstractRefreshJob(String name, String urlString) {
-		super(name);
+		this(name);
 		this.urlString = urlString;
+	}
+
+	public AbstractRefreshJob(String name) {
+		super(name);
 		setPriority(LONG);
 		cacheFile = getCacheFile();
 		if (cacheFile.exists()) {
@@ -78,7 +89,7 @@ public abstract class AbstractRefreshJob extends Job {
 			}
 		}
 	}
-
+	
 	public abstract File getCacheFile();
 	
 	public abstract File getValidCacheFile();
@@ -216,7 +227,7 @@ public abstract class AbstractRefreshJob extends Job {
 				tempFile.deleteOnExit();
 				OutputStream destination = new FileOutputStream(tempFile);
 				IStatus status = new URLTransportUtility().download(
-						cacheFile.getName(), urlString, destination, TIME_OUT, monitor);
+						cacheFile.getName(), getUrlString(), destination, TIME_OUT, monitor);
 				URL url = getURL();
 				if (monitor.isCanceled()) {
 					return getValidEntries(monitor);
@@ -293,7 +304,7 @@ public abstract class AbstractRefreshJob extends Job {
 	private URL getURL() {
 		URL url;
 		try {
-			url = new URL(urlString);
+			url = new URL(getUrlString());
 			return url;
 		} catch (MalformedURLException e) {
 			exception = e;

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/jobs/RefreshBuzzJob.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/jobs/RefreshBuzzJob.java
@@ -31,7 +31,7 @@ public class RefreshBuzzJob extends AbstractRefreshJob {
 
 	
 	private RefreshBuzzJob() {
-		super("Refreshing JBoss Buzz...", ProjectExamplesActivator.getDefault().getConfigurator().getBuzzUrl());
+		super("Refreshing JBoss Buzz...");
 	}
 
 	@Override
@@ -48,5 +48,10 @@ public class RefreshBuzzJob extends AbstractRefreshJob {
 	@Override
 	public File getValidCacheFile() {
 		return getFile(VALID_CACHE_FILE);
+	}
+	
+	@Override
+	public String getUrlString() {
+		return ProjectExamplesActivator.getDefault().getConfigurator().getBuzzUrl();
 	}
 }


### PR DESCRIPTION
When displaying Central, ProxyWizardManager and RefreshBuzzJob instantiations trigger fetching of remote resources (ide-config.properties), that could block the UI for an indefinite amount of time.
The values being looked up are not required until later, by methods running in Jobs, so the current fix consists in performing the lookups only when necessary and when it's safe to do it.

The fix is certainly not ideal, other parts of the code calling PropertiesHelper.getPropertiesProvider().getValue(...) might require better handling as well, but this would require major refactoring at the foundation level (introducing/handling timeouts).

Until a better redesign can be performed, the current fix makes Central not blocking the UI, as expected. Some jobs keeps running for a very long time in the background but they can be cancelled any time.

Signed-off-by: Fred Bricon fbricon@gmail.com
