### PR TITLE
JBIDE-18538 - Cheatsheet is not opened when project is imported as existing maven project

### DIFF
--- a/examples/plugins/org.jboss.tools.project.examples.cheatsheet/plugin.xml
+++ b/examples/plugins/org.jboss.tools.project.examples.cheatsheet/plugin.xml
@@ -126,5 +126,11 @@
             id="org.jboss.tools.project.examples.cheatsheet.getProjectForCheatsheet">
       </command>
    </extension>
+   
+   <extension
+         point="org.eclipse.ui.startup">
+      <startup class="org.jboss.tools.project.examples.cheatsheet.Startup">
+      </startup>
+   </extension>
 
 </plugin>

--- a/examples/plugins/org.jboss.tools.project.examples.cheatsheet/src/org/jboss/tools/project/examples/cheatsheet/Startup.java
+++ b/examples/plugins/org.jboss.tools.project.examples.cheatsheet/src/org/jboss/tools/project/examples/cheatsheet/Startup.java
@@ -1,0 +1,26 @@
+/*************************************************************************************
+ * Copyright (c) 2008-2014 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.jboss.tools.project.examples.cheatsheet;
+
+import org.eclipse.ui.IStartup;
+
+/**
+ * 
+ * @author snjeza
+ *
+ */
+public class Startup implements IStartup {
+
+	@Override
+	public void earlyStartup() {
+	}
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-18538
Cheatsheet is not opened when project is imported as existing maven project
