### PR TITLE
JBIDE-18777 : bump central version to 1.3.1-SNAPSHOT and parent to 4.2.1-SNAPSHOT

### DIFF
--- a/central/features/org.jboss.tools.central.feature/feature.xml
+++ b/central/features/org.jboss.tools.central.feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.jboss.tools.central.feature" label="%featureName" version="1.3.0.qualifier" provider-name="%providerName" plugin="org.jboss.tools.central"> 
+<feature id="org.jboss.tools.central.feature" label="%featureName" version="1.3.1.qualifier" provider-name="%providerName" plugin="org.jboss.tools.central"> 
    <description>
       %description
    </description>

--- a/central/features/org.jboss.tools.central.feature/pom.xml
+++ b/central/features/org.jboss.tools.central.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>features</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.features</groupId>
 	<artifactId>org.jboss.tools.central.feature</artifactId>

--- a/central/features/org.jboss.tools.central.test.feature/feature.xml
+++ b/central/features/org.jboss.tools.central.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.central.test.feature"
       label="JBoss Tools - Tests - JBoss Central"
-      version="1.3.0.qualifier"
+      version="1.3.1.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description>

--- a/central/features/org.jboss.tools.central.test.feature/pom.xml
+++ b/central/features/org.jboss.tools.central.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>features</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.central.features</groupId>
 	<artifactId>org.jboss.tools.central.test.feature</artifactId>

--- a/central/features/org.jboss.tools.central.themes.feature/feature.xml
+++ b/central/features/org.jboss.tools.central.themes.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.central.themes.feature"
       label="%featureName"
-      version="1.3.0.qualifier"
+      version="1.3.1.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.community.central">
 

--- a/central/features/org.jboss.tools.central.themes.feature/pom.xml
+++ b/central/features/org.jboss.tools.central.themes.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>features</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.features</groupId>
 	<artifactId>org.jboss.tools.central.themes.feature</artifactId>

--- a/central/features/org.jboss.tools.community.central.feature/feature.xml
+++ b/central/features/org.jboss.tools.community.central.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.community.central.feature"
       label="%featureName"
-      version="1.3.0.qualifier"
+      version="1.3.1.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.community.central">
 

--- a/central/features/org.jboss.tools.community.central.feature/pom.xml
+++ b/central/features/org.jboss.tools.community.central.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>features</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.features</groupId>
 	<artifactId>org.jboss.tools.community.central.feature</artifactId>

--- a/central/features/pom.xml
+++ b/central/features/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>central</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central</groupId>
 	<artifactId>features</artifactId>

--- a/central/plugins/org.jboss.tools.central.themes/META-INF/MANIFEST.MF
+++ b/central/plugins/org.jboss.tools.central.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Themes
 Bundle-SymbolicName: org.jboss.tools.central.themes;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.1.qualifier
 Bundle-Activator: org.jboss.tools.central.themes.Activator
 Bundle-Vendor: JBoss, by Red Hat
 Require-Bundle: org.eclipse.ui,

--- a/central/plugins/org.jboss.tools.central.themes/pom.xml
+++ b/central/plugins/org.jboss.tools.central.themes/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.plugins</groupId>
 	<artifactId>org.jboss.tools.central.themes</artifactId> 

--- a/central/plugins/org.jboss.tools.central/META-INF/MANIFEST.MF
+++ b/central/plugins/org.jboss.tools.central/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.central; singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.1.qualifier
 Bundle-Activator: org.jboss.tools.central.JBossCentralActivator
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/central/plugins/org.jboss.tools.central/pom.xml
+++ b/central/plugins/org.jboss.tools.central/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.plugins</groupId>
 	<artifactId>org.jboss.tools.central</artifactId>

--- a/central/plugins/org.jboss.tools.community.central/META-INF/MANIFEST.MF
+++ b/central/plugins/org.jboss.tools.community.central/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.community.central;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.1.qualifier
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin
 Require-Bundle: org.jboss.tools.central;bundle-version="1.0.0"

--- a/central/plugins/org.jboss.tools.community.central/pom.xml
+++ b/central/plugins/org.jboss.tools.community.central/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.plugins</groupId>
 	<artifactId>org.jboss.tools.community.central</artifactId>

--- a/central/plugins/pom.xml
+++ b/central/plugins/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>central</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central</groupId>
 	<artifactId>plugins</artifactId>

--- a/central/pom.xml
+++ b/central/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>central.maven.examples</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>central</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>central.all</name>
 	<packaging>pom</packaging>
 	 <!--

--- a/central/tests/org.jboss.tools.central.test/META-INF/MANIFEST.MF
+++ b/central/tests/org.jboss.tools.central.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.central.test;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.1.qualifier
 Bundle-Activator: org.jboss.tools.central.test.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/central/tests/org.jboss.tools.central.test/pom.xml
+++ b/central/tests/org.jboss.tools.central.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.tests</groupId>
 	<artifactId>org.jboss.tools.central.test</artifactId>

--- a/central/tests/pom.xml
+++ b/central/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>central</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central</groupId>
 	<artifactId>tests</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>central.maven.examples</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>examples</artifactId>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>central.maven.examples</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>maven</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.0.Final-SNAPSHOT</version>
+		<version>4.2.1.CR1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>central.maven.examples</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.1-SNAPSHOT</version>
 	<name>central.maven.examples.all</name>
 	<packaging>pom</packaging>
 	<properties>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>central.maven.examples</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central</groupId>
 	<artifactId>central.maven.examples.site</artifactId>


### PR DESCRIPTION
Only central was changed for this release

Signed-off-by: Fred Bricon fbricon@gmail.com
