### PR TITLE
JBIDE-19272 : add JBoss Developer search engine

### DIFF
--- a/central/plugins/org.jboss.tools.central/META-INF/MANIFEST.MF
+++ b/central/plugins/org.jboss.tools.central/META-INF/MANIFEST.MF
@@ -36,7 +36,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.e4.ui.workbench;bundle-version="1.0.0",
  org.eclipse.core.filesystem,
  org.eclipse.ui.net,
- org.jboss.tools.discovery.core;bundle-version="1.0.0"
+ org.jboss.tools.discovery.core;bundle-version="1.0.0",
+ org.jboss.tools.common.help.ui;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin

--- a/central/plugins/org.jboss.tools.central/plugin.xml
+++ b/central/plugins/org.jboss.tools.central/plugin.xml
@@ -330,4 +330,20 @@
        </page>
     </extension>		
 
+  <extension
+         point="org.eclipse.help.ui.searchEngine">
+	<engine
+	      enabled="true"
+	      engineTypeId="org.jboss.tools.common.help.ui.search.SearchiskoSearchEngine"
+	      id="org.jboss.tools.developer.search"
+	      label="JBoss Developer Search">
+	      <description>
+	        Searches blog posts, articles, web pages and solutions on JBoss Community and Red Hat websites.
+	      </description>
+	      <param 
+      			name="url" 
+      			value="http://dcp.jboss.org/v1/rest/search?query={expression}+AND+sys_type%3A(blogpost+article+webpage+solution)&amp;size=100">
+      	  </param>
+	</engine>
+  </extension>
 </plugin>

--- a/maven/plugins/.project
+++ b/maven/plugins/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>plugins</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
requires adding the org.jboss.tools.help.ui plugin to base before applying this PR

Signed-off-by: Fred Bricon <fbricon@gmail.com>