### PR TITLE
JBIDE-17814 - Empty editor is opened instead of Central editor

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedHtmlPage.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedHtmlPage.java
@@ -290,6 +290,12 @@ public class GettingStartedHtmlPage extends AbstractJBossCentralPage implements 
 					
 					return Status.OK_STATUS;
 				}
+				
+				@Override
+				public boolean belongsTo(Object family) {
+					return family == JBossCentralActivator.JBOSS_CENTRAL_FAMILY;
+				}
+				
 			};
 			centralJob.schedule();
 		}  catch (Throwable t) {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-17814
Empty editor is opened instead of Central editor