### PR TITLE
JBIDE-20609: Better integration of EA in user workflow

### DIFF
--- a/central/plugins/org.jboss.tools.central/plugin.properties
+++ b/central/plugins/org.jboss.tools.central/plugin.properties
@@ -12,3 +12,5 @@ hybrid.mobile.wizard.description=Create a hybrid mobile application using Apache
 maven.wizard.description=Create a Maven-based project.
 jboss.central.menu.name=JBoss Central
 forge.wizard.description=This project is a sample project that will show how to build an JavaEE application with AngularJS, HTML5 and Bootstrap 3 by using JBoss Forge. \nThe application is deployable to JBoss Enterprise Platform 6 or JBoss Application Server 7.1 or higher.
+
+earlyAccessInstallationPageTitle=Early Access

--- a/central/plugins/org.jboss.tools.central/plugin.xml
+++ b/central/plugins/org.jboss.tools.central/plugin.xml
@@ -314,7 +314,7 @@
        <page
              class="org.jboss.tools.central.installation.CentralInstallationPage"
              id="org.jboss.tools.central.installation.centralInstallationPage"
-             name="JBoss Central">
+             name="%earlyAccessInstallationPageTitle">
        </page>
     </extension>
 

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/Messages.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/Messages.java
@@ -15,10 +15,8 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.jboss.tools.central.messages"; //$NON-NLS-1$
 
-	public static String DiscoveryViewer_Certification_Label0;
 	public static String DiscoveryViewer_X_installed;
 	public static String DiscoveryViewer_Hide_installed;
-	public static String DiscoveryViewer_Enable_EarlyAccess;
 	public static String DiscoveryViewer_Show_only_most_recent;
 	public static String DiscoveryViewer_filtersLink;
 	public static String DiscoveryViewer_noFeatureToShow;
@@ -35,12 +33,12 @@ public class Messages extends NLS {
 	public static String updateWithCount;
 	public static String selectAll;
 	public static String deselectAll;
+	public static String manageEarlyAccess;
 	
-	public static String SoftwarePage_earlyAccessSection_Title;
-	public static String SoftwarePage_earlyAccessSection_message;
-	public static String SoftwarePage_nothingToInstall_title;
-	public static String SoftwarePage_nothingToInstall_description;
 	public static String EarlyAccess_Description;
+	public static String EarlyAccessSites_Description;
+	public static String disableEarlyAccess_title;
+	public static String disableEarlyAccess_description;
 
 	public static String remainingEarlyAccessConnectors_title;
 	public static String remainingEarlyAccessConnectors_message;
@@ -55,6 +53,7 @@ public class Messages extends NLS {
 	public static String additionalSoftwareRequired_message;
 	public static String unableToInstallConnectors_title;
 	public static String unableToInstallConnectors_message;
+
 
 	static {
 		// initialize resource bundle

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedHtmlPage.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedHtmlPage.java
@@ -414,7 +414,7 @@ public class GettingStartedHtmlPage extends AbstractJBossCentralPage implements 
 							return;
 						}
 						IRunnableContext context = new ProgressMonitorDialog(shell);
-						if (!JBossDiscoveryUi.installByIds(proxyWizard.getRequiredComponentIds(), context)) {
+						if (!JBossDiscoveryUi.installByIds(proxyWizard.getRequiredComponentIds(), true, context)) {
 							MessageDialog.openError(getSite().getShell(), Messages.unableToInstallConnectors_title, Messages.unableToInstallConnectors_message);
 						}
 					} else {

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/EarlyAccessOrMostRecentVersionFilter.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/EarlyAccessOrMostRecentVersionFilter.java
@@ -29,8 +29,8 @@ import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
-import org.jboss.tools.central.editors.xpl.ConnectorDescriptorItemUi;
 import org.jboss.tools.central.editors.xpl.DiscoveryViewer;
+import org.jboss.tools.discovery.core.internal.connectors.ConnectorDescriptorItemUi;
 import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
 
 /**

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/HideEarlyAccessWhenRegularExistsFilter.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/HideEarlyAccessWhenRegularExistsFilter.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Mickael Istria (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+package org.jboss.tools.central.editors.xpl.filters;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
+import org.jboss.tools.central.editors.xpl.DiscoveryViewer;
+import org.jboss.tools.discovery.core.internal.connectors.ConnectorDescriptorItemUi;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
+
+/**
+ * When a connector exists in both Early-Access and Regular version,
+ * show only regular.
+ * @author mistria
+ *
+ */
+public class HideEarlyAccessWhenRegularExistsFilter extends ViewerFilter {
+
+	@Override
+	public boolean select(Viewer viewer, Object parent, Object item) {
+		Assert.isTrue(viewer instanceof DiscoveryViewer, "This filter only applies on DiscoveryViewer");
+		DiscoveryViewer discoveryViewer = (DiscoveryViewer)viewer;
+		if (! (item instanceof ConnectorDescriptor)) { // category headers
+			return true;
+		}
+		ConnectorDescriptor desc = (ConnectorDescriptor)item;
+		
+		if (JBossDiscoveryUi.isEarlyAccess(desc)) {
+			Set<ConnectorDescriptor> visibleConnectors = new HashSet<>();
+			for (ConnectorDescriptorItemUi otherConnector : discoveryViewer.getAllConnectorsItemsUi()) {
+				if (otherConnector.getConnector() != desc && otherConnector.isVisible() && otherConnector.getConnector().getId().equals(desc.getId())) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+}

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/HideRegularConnectorWhenEAExists.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/HideRegularConnectorWhenEAExists.java
@@ -1,0 +1,35 @@
+package org.jboss.tools.central.editors.xpl.filters;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
+import org.jboss.tools.central.editors.xpl.DiscoveryViewer;
+import org.jboss.tools.discovery.core.internal.connectors.ConnectorDescriptorItemUi;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
+
+public class HideRegularConnectorWhenEAExists extends ViewerFilter {
+
+	@Override
+	public boolean select(Viewer viewer, Object parentElement, Object item) {
+		Assert.isTrue(viewer instanceof DiscoveryViewer, "This filter only applies on DiscoveryViewer");
+		DiscoveryViewer discoveryViewer = (DiscoveryViewer)viewer;
+		if (! (item instanceof ConnectorDescriptor)) { // category headers
+			return true;
+		}
+		ConnectorDescriptor desc = (ConnectorDescriptor)item;
+		
+		if (!JBossDiscoveryUi.isEarlyAccess(desc)) {
+			for (ConnectorDescriptorItemUi otherConnector : discoveryViewer.getAllConnectorsItemsUi()) {
+				if (JBossDiscoveryUi.isEarlyAccess(otherConnector.getConnector()) && otherConnector.isVisible() && otherConnector.getConnector().getId().equals(desc.getId())) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+}

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/installation/CentralInstallationPage.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/installation/CentralInstallationPage.java
@@ -10,48 +10,119 @@
  ************************************************************************************/
 package org.jboss.tools.central.installation;
 
+import java.net.URI;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.ui.ProvUIMessages;
 import org.eclipse.equinox.internal.p2.ui.dialogs.ILayoutConstants;
 import org.eclipse.equinox.internal.p2.ui.viewers.IUColumnConfig;
 import org.eclipse.equinox.internal.p2.ui.viewers.IUDetailsLabelProvider;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.about.InstallationPage;
 import org.eclipse.ui.dialogs.FilteredTree;
 import org.eclipse.ui.dialogs.PatternFilter;
 import org.jboss.tools.central.JBossCentralActivator;
 import org.jboss.tools.central.Messages;
+import org.jboss.tools.central.preferences.PreferenceKeys;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
 
 public class CentralInstallationPage extends InstallationPage {
 
 	//private static final int COLUMN_INDEX_ID = 0;
 	//private static final int COLUMN_INDEX_LABEL = COLUMN_INDEX_ID + 1;
 	//private static final int COLUMN_INDEX_VERSION = COLUMN_INDEX_LABEL + 1;
+	public static final String PAGE_ID = "org.jboss.tools.central.installation.centralInstallationPage"; //$NON-NLS-1$
 	
+	private static final class ArrayTreeContentProvider implements ITreeContentProvider {
+		@Override
+		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+		}
+
+		@Override
+		public void dispose() {
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			return false;
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			return null;
+		}
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			return new ArrayContentProvider().getElements(inputElement);
+		}
+
+		@Override
+		public Object[] getChildren(Object parentElement) {
+			return null;
+		}
+	}
+
+	private Set<IInstallableUnit> earlyAccessUnits;
+	private Set<String> earlyAccessSites;
+	private FilteredTree iusViewer;
+	private InstallationChecker installChecker;
+	private FilteredTree sitesViewer;
+
 	public CentralInstallationPage() {
 	}
 
 	@Override
 	public void createControl(Composite parent) {
-		Label earlyAccessLabel = new Label(parent, SWT.WRAP);
-		earlyAccessLabel.setText(Messages.EarlyAccess_Description);
-		GridData layoutData = new GridData(SWT.FILL, SWT.FILL, false, false);
-		layoutData.widthHint = 700;
-		earlyAccessLabel.setLayoutData(layoutData);
-		
-		InstallationChecker installChecker = null;
+		installChecker = null;
 		try {
 			installChecker = InstallationChecker.getInstance();
-			FilteredTree iusViewer = new FilteredTree(parent, SWT.MULTI | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER, new PatternFilter(), false);
+		} catch (ProvisionException ex) {
+			JBossCentralActivator.getDefault().getLog().log(new Status(IStatus.ERROR,
+					JBossCentralActivator.PLUGIN_ID,
+					ex.getMessage(),
+					ex));
+		}
+
+		{
+			Composite header = new Composite(parent, SWT.NONE);
+			GridData layoutData = new GridData(SWT.FILL, SWT.FILL, false, false);
+			layoutData.widthHint = 700;
+			header.setLayoutData(layoutData);
+			GridLayout headerLayout = new GridLayout(2, false);
+			header.setLayout(headerLayout);
+			Label warningIcon = new Label(header, SWT.NONE);
+			warningIcon.setImage(parent.getDisplay().getSystemImage(SWT.ICON_WARNING));
+			Label earlyAccessLabel = new Label(header, SWT.WRAP);
+			earlyAccessLabel.setText(Messages.EarlyAccess_Description);
+			earlyAccessLabel.setLayoutData(new GridData(SWT.FILL, SWT.DEFAULT, true, false));
+			
+			
+			iusViewer = new FilteredTree(parent, SWT.MULTI | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER, new PatternFilter(), false);
 			IUColumnConfig[] columnsConfig = new IUColumnConfig[] {new IUColumnConfig(ProvUIMessages.ProvUI_NameColumnTitle, IUColumnConfig.COLUMN_NAME, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH), new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle, IUColumnConfig.COLUMN_VERSION, ILayoutConstants.DEFAULT_SMALL_COLUMN_WIDTH), new IUColumnConfig(ProvUIMessages.ProvUI_IdColumnTitle, IUColumnConfig.COLUMN_ID, ILayoutConstants.DEFAULT_COLUMN_WIDTH), new IUColumnConfig(ProvUIMessages.ProvUI_ProviderColumnTitle, IUColumnConfig.COLUMN_PROVIDER, ILayoutConstants.DEFAULT_COLUMN_WIDTH)};
 			iusViewer.getViewer().setLabelProvider(new IUDetailsLabelProvider(iusViewer, columnsConfig, parent.getShell()));
 			// copied from AvailableIUGroup
@@ -63,44 +134,61 @@ public class CentralInstallationPage extends InstallationPage {
 				tc.setText(column.getColumnTitle());
 				tc.setWidth(column.getWidthInPixels(tree));
 			}
-			iusViewer.getViewer().setContentProvider(new ITreeContentProvider() {
-				@Override
-				public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-				}
-				
-				@Override
-				public void dispose() {
-				}
-				
-				@Override
-				public boolean hasChildren(Object element) {
-					return false;
-				}
-				
-				@Override
-				public Object getParent(Object element) {
-					return null;
-				}
-				
-				@Override
-				public Object[] getElements(Object inputElement) {
-					return new ArrayContentProvider().getElements(inputElement);
-				}
-				
-				@Override
-				public Object[] getChildren(Object parentElement) {
-					return null;
-				}
-			});
-			iusViewer.getViewer().setInput(installChecker.getEarlyAccessUnits());
+			iusViewer.getViewer().setContentProvider(new ArrayTreeContentProvider());
+			earlyAccessUnits = installChecker.getEarlyAccessUnits();
+			iusViewer.getViewer().setInput(earlyAccessUnits);
 			iusViewer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		} catch (ProvisionException ex) {
-			JBossCentralActivator.log(ex);
-			Label label = new Label(parent, SWT.NONE);
-			label.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_RED));
-			label.setText("ERROR: " + ex.getMessage() + " See log for details.");
 		}
 		
+		{
+			Label earlyAccessSitesLabel = new Label(parent, SWT.WRAP);
+			earlyAccessSitesLabel.setText(Messages.EarlyAccessSites_Description);
+			GridData layoutData = new GridData(SWT.FILL, SWT.FILL, false, false);
+			layoutData.widthHint = 700;
+			earlyAccessSitesLabel.setLayoutData(layoutData);
+			sitesViewer = new FilteredTree(parent, SWT.MULTI | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER, new PatternFilter(), false);
+			sitesViewer.getViewer().setContentProvider(new ArrayTreeContentProvider());
+			this.earlyAccessSites = installChecker.getActiveEarlyAccessURLs(new NullProgressMonitor());
+			sitesViewer.getViewer().setInput(this.earlyAccessSites);
+		}
+		
+		final Button disableEarlyAccessButton = new Button(parent, SWT.PUSH);
+		disableEarlyAccessButton.setText(Messages.disableEarlyAccess_title);
+		disableEarlyAccessButton.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_TOOL_DELETE));
+		disableEarlyAccessButton.setToolTipText(Messages.disableEarlyAccess_description);
+		disableEarlyAccessButton.addSelectionListener(new SelectionAdapter() {
+	    	@Override
+	    	public void widgetSelected(SelectionEvent e) {
+	    		disableEarlyAccess(disableEarlyAccessButton);
+	    	}
+	    });
+		disableEarlyAccessButton.setEnabled(JBossCentralActivator.getDefault().getPreferences().getBoolean(JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS, false));
+		
 	}
-
+	
+	private void disableEarlyAccess(final Button disableEarlyAccessButton) {
+		// remaining early-access connectors
+		if (MessageDialog.openConfirm(disableEarlyAccessButton.getShell(), Messages.disableEarlyAccess_title, Messages.disableEarlyAccess_description)) {
+			// remove early-access sites
+			ProgressMonitorDialog progressMonitorDialog = new ProgressMonitorDialog(disableEarlyAccessButton.getShell());
+			IProvisioningAgent agent = (IProvisioningAgent)JBossCentralActivator.getDefault().getService(IProvisioningAgent.SERVICE_NAME);
+			final IMetadataRepositoryManager metadataRepositoryManager = (IMetadataRepositoryManager)agent.getService(IMetadataRepositoryManager.SERVICE_NAME);
+			IArtifactRepositoryManager artifactsitoryManager = (IArtifactRepositoryManager)agent.getService(IArtifactRepositoryManager.SERVICE_NAME);
+			for (String site : this.earlyAccessSites) {
+				try {
+					URI repoUri = new URI(site);
+					metadataRepositoryManager.removeRepository(repoUri);
+					artifactsitoryManager.removeRepository(repoUri);
+				} catch (Exception ex) {
+					JBossCentralActivator.getDefault().getLog().log(new Status(IStatus.ERROR,
+						JBossCentralActivator.PLUGIN_ID,
+						ex.getMessage(),
+						ex));
+				}
+			}
+			this.sitesViewer.getViewer().setInput(this.installChecker.getActiveEarlyAccessURLs(new NullProgressMonitor()));
+			JBossCentralActivator.getDefault().getPreferences().putBoolean(JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS, false);
+			disableEarlyAccessButton.setEnabled(false);
+		}
+	}
 }

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/messages.properties
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/messages.properties
@@ -1,8 +1,6 @@
-DiscoveryViewer_Certification_Label0=by {0}, {1}, <a>{2}</a>
 DiscoveryViewer_X_installed={0} (INSTALLED - {1})
 
 DiscoveryViewer_Hide_installed = Show installed
-DiscoveryViewer_Enable_EarlyAccess=Enable Early Access
 DiscoveryViewer_Show_only_most_recent = Show only most recent version of connector
 
 DiscoveryViewer_filtersLink = Filters...
@@ -20,6 +18,7 @@ uninstallWithCount=Uninstall ({0})
 updateWithCount=Update ({0})
 selectAll=Select All
 deselectAll=Deselect All
+manageEarlyAccess=Manage Early Access
 
 remainingEarlyAccessConnectors_title=Remaining Early Access features
 remainingEarlyAccessConnectors_message=Some Early Access features are still installed in your IDE, so are currently in an unsupported state.\n\
@@ -30,18 +29,11 @@ To return to a supported state, consider uninstalling the following connectors.\
 EarlyAccess_Description=Early Access features contain new functionality and/or fixes that are under development. \
 You are encouraged to use these features and to give feedback but be aware that these features are NOT officially supported, \
 NOT guaranteed to work correctly, and subject to removal from JBoss Central at any time, for any reason. Use them at your own risk!
-
-SoftwarePage_earlyAccessSection_Title=Early Access Features
-SoftwarePage_earlyAccessSection_message=Early Access features contain new functionality and/or fixes that are under development. \
-You are encouraged to use these features and to give feedback but be aware that these features are NOT officially supported, \
-NOT guaranteed to work correctly, and subject to removal from JBoss Central at any time, for any reason. Use them at your own risk!\n\
-\n\
-An Early Access update site will be added to the list of Available Software Sites, and may then be used to resolve dependencies \
-or provide newer versions of software when performing an update or install.\n\
-\n\
-I understand these conditions, and still want to enable Early Access features.
-SoftwarePage_nothingToInstall_title=Everything up-to-date
-SoftwarePage_nothingToInstall_description=All selected connectors are already installed and up-to-date.
+EarlyAccessSites_Description=Those active repositories contain some Early-Access content. They may affect other installations or \
+updates (providing some Early-Access plugins where you would expect supported content.
+disableEarlyAccess_title=Disable Early-Access and related software sites
+disableEarlyAccess_description=This will disable the Early-Access repositories. Early Access features remain installed in your IDE, but updates won't be available.\n\
+Do you want to continue?
 
 noEngineError_message=Webkit is not installed.\n\
 To use JBoss Tools Central please install libwebkitgtk library with your favourite package manager.\n\

--- a/discovery/plugins/org.jboss.tools.discovery.core/META-INF/MANIFEST.MF
+++ b/discovery/plugins/org.jboss.tools.discovery.core/META-INF/MANIFEST.MF
@@ -21,7 +21,9 @@ Require-Bundle: org.jboss.tools.foundation.core;bundle-version="1.1.0",
  org.eclipse.equinox.p2.core,
  org.eclipse.equinox.p2.director;bundle-version="2.3.100",
  org.eclipse.mylyn.commons.core,
- org.apache.commons.io
+ org.apache.commons.io,
+ org.eclipse.mylyn.commons.workbench,
+ org.eclipse.mylyn.commons.ui
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.jboss.tools.discovery.core.internal,

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/Messages.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/Messages.java
@@ -17,6 +17,15 @@ public class Messages extends NLS {
 
 	public static String preparingUninstall;
 	public static String UsageEventTypeInstallLabelDescription;
+	
+	public static String SoftwarePage_earlyAccessSection_Title;
+	public static String SoftwarePage_earlyAccessSection_message;
+	public static String SoftwarePage_nothingToInstall_title;
+	public static String SoftwarePage_nothingToInstall_description;
+	public static String DiscoveryViewer_selectConnectorFlavor_description;
+	public static String DiscoveryViewer_selectConnectorFlavor_title;
+	public static String DiscoveryViewer_Certification_Label0;
+	
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/ExpressionBasedDiscoveryConnector.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/ExpressionBasedDiscoveryConnector.java
@@ -15,6 +15,7 @@ import org.eclipse.mylyn.internal.discovery.core.model.ValidationException;
 import org.eclipse.osgi.util.NLS;
 import org.jboss.tools.foundation.core.expressions.ExpressionResolutionException;
 import org.jboss.tools.foundation.core.expressions.ExpressionResolver;
+import org.jboss.tools.foundation.core.expressions.ExpressionResolver.SystemPropertiesVariableResolver;
 import org.jboss.tools.foundation.core.expressions.IVariableResolver;
 import org.jboss.tools.foundation.core.properties.IPropertiesProvider;
 import org.jboss.tools.foundation.core.properties.PropertiesHelper;

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/JBossDiscoveryUi.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/JBossDiscoveryUi.java
@@ -12,12 +12,11 @@ package org.jboss.tools.discovery.core.internal.connectors;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -25,19 +24,38 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.window.IShellProvider;
+import org.eclipse.mylyn.internal.discovery.core.model.AbstractDiscoverySource;
 import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
 import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDiscovery;
+import org.eclipse.mylyn.internal.discovery.core.model.DiscoveryConnector;
 import org.eclipse.mylyn.internal.discovery.core.model.DiscoveryFeedbackJob;
+import org.eclipse.mylyn.internal.discovery.core.model.Icon;
+import org.eclipse.mylyn.internal.discovery.core.model.Overview;
 import org.eclipse.mylyn.internal.discovery.ui.DiscoveryUi;
 import org.eclipse.mylyn.internal.discovery.ui.InstalledItem;
 import org.eclipse.mylyn.internal.discovery.ui.UninstallRequest;
-import org.eclipse.mylyn.internal.discovery.ui.wizards.Messages;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Widget;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.jboss.tools.discovery.core.internal.DiscoveryActivator;
+import org.jboss.tools.discovery.core.internal.Messages;
 import org.jboss.tools.usage.event.UsageEventType;
 import org.jboss.tools.usage.event.UsageReporter;
 
@@ -89,7 +107,7 @@ public class JBossDiscoveryUi {
 			recordInstalled(descriptors);
 		} catch (InvocationTargetException e) {
 			IStatus status = new Status(IStatus.ERROR, DiscoveryActivator.PLUGIN_ID, NLS.bind(
-					Messages.ConnectorDiscoveryWizard_installProblems, new Object[] { e.getCause().getMessage() }),
+					org.eclipse.mylyn.internal.discovery.ui.wizards.Messages.ConnectorDiscoveryWizard_installProblems, new Object[] { e.getCause().getMessage() }),
 					e.getCause());
 			StatusManager.getManager().handle(status, StatusManager.SHOW | StatusManager.BLOCK | StatusManager.LOG);
 			return false;
@@ -127,7 +145,7 @@ public class JBossDiscoveryUi {
 			}
 		} catch (InvocationTargetException e) {
 			IStatus status = new Status(IStatus.ERROR, DiscoveryActivator.PLUGIN_ID, NLS.bind(
-					Messages.ConnectorDiscoveryWizard_installProblems, new Object[] { e.getCause().getMessage() }),
+					org.eclipse.mylyn.internal.discovery.ui.wizards.Messages.ConnectorDiscoveryWizard_installProblems, new Object[] { e.getCause().getMessage() }),
 					e.getCause());
 			StatusManager.getManager().handle(status, StatusManager.SHOW | StatusManager.BLOCK | StatusManager.LOG);
 			return false;
@@ -176,13 +194,14 @@ public class JBossDiscoveryUi {
 	/**
 	 * 
 	 * @param connectorsId
+	 * @param interactive Whether user is asked for choice. If false, will automatically select best one according to EA state
 	 * @param context
 	 * @return the set of resolved connector. In case a connector wasn't resolved, it's simply absent in the set, so you
 	 *         should check size or the output for completeness. 
 	 */
-	public static Collection<ConnectorDescriptor> resolveToConnectors(Collection<String> connectorsId, IRunnableContext context) {
-		Map<String, ConnectorDescriptor> res = new HashMap<>();
+	public static Collection<ConnectorDescriptor> resolveToConnectors(Collection<String> connectorsId, boolean interactive, IRunnableContext context) {
 		final ConnectorDiscovery catalog = DiscoveryUtil.createConnectorDiscovery();
+		IShellProvider shellProvider = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		try {
 			context.run(true, true, new IRunnableWithProgress() {
 				@Override
@@ -195,31 +214,75 @@ public class JBossDiscoveryUi {
 		} catch (InvocationTargetException ex) {
 			DiscoveryActivator.getDefault().getLog().log(new Status(IStatus.ERROR, DiscoveryActivator.getDefault().getBundle().getSymbolicName(), ex.getMessage(), ex));
 		}
-		for (ConnectorDescriptor connector : catalog.getConnectors()) {
-			if (connectorsId.contains(connector.getId()) &&
-				connector.getInstallableUnits() != null &&
-				!connector.getInstallableUnits().isEmpty() &&
-				isInstallableConnector(connector)) {
-				if (isEarlyAccess(connector)) {
-					if (isEarlyAccessEnabled()) {
-						// always prefer EA connector when EA available
-						res.put(connector.getId(), connector);
-					}
-					// but never use EA connector when EA not enabled
-				} else if (!res.containsKey(connector.getId()) /*no better connector so far*/) {
-					res.put(connector.getId(), connector);
-				}
+		boolean hasEarlyAccessContent = false;
+		Set<ConnectorDescriptor> res = new HashSet<>();
+		Set<String> notResolved = new HashSet<>();
+		for (String connectorId : connectorsId) {
+			ConnectorDescriptor toInstall = resolveSingleConnector(catalog, connectorId, interactive, shellProvider);
+			if (toInstall != null) {
+				hasEarlyAccessContent |= JBossDiscoveryUi.isEarlyAccess(toInstall);
+				res.add(toInstall);
+			} else {
+				notResolved.add(connectorId);
 			}
 		}
-		if (res.size() != connectorsId.size()) {
-			Set<String> missingConnectoes = new HashSet<>(connectorsId);
-			missingConnectoes.removeAll(res.keySet());
+
+		if (hasEarlyAccessContent) {
+			if (MessageDialog.openConfirm(shellProvider.getShell(), Messages.SoftwarePage_earlyAccessSection_Title, Messages.SoftwarePage_earlyAccessSection_message)) {
+				DiscoveryActivator.getDefault().getPreferences().putBoolean(JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS, true);
+			} else {
+				return null;
+			}
+		}
+		
+		if (!notResolved.isEmpty()) {
 			DiscoveryActivator.getDefault().getLog().log(new Status(
 				IStatus.ERROR,
 				DiscoveryActivator.getDefault().getBundle().getSymbolicName(),
-				"Could not resolve the following connectorIds to catalog entries: " + missingConnectoes.toString())); //$NON-NLS-1$
+				"Could not resolve the following connectorIds to catalog entries: " + notResolved.toString())); //$NON-NLS-1$
 		}
-		return res.values();
+		
+		return res;
+	}
+
+	private static ConnectorDescriptor resolveSingleConnector(final ConnectorDiscovery catalog, String connectorId,
+			boolean interactive, IShellProvider shellProvider) {
+		Set<DiscoveryConnector> alternatives = new HashSet<>();
+		for (DiscoveryConnector otherConnector : catalog.getConnectors()) {
+			if (otherConnector.getId().equals(connectorId)) {
+				alternatives.add(otherConnector);
+			}
+		}
+		ConnectorDescriptor toInstall = null;
+		if (alternatives.size() == 1) {
+			toInstall = alternatives.iterator().next();
+		} else if (alternatives.size() > 1) {
+			if (interactive) {
+				SelectConnectorDialog selectConnectorDialog = new SelectConnectorDialog(shellProvider, alternatives);
+				if (selectConnectorDialog.open() == Dialog.OK) {
+					toInstall = selectConnectorDialog.getSelectedConnector();
+				} else {
+					return null;
+				}
+			} else {
+				for (ConnectorDescriptor alternative : alternatives) {
+					if (alternative.getInstallableUnits() != null &&
+						!alternative.getInstallableUnits().isEmpty() &&
+						isInstallableConnector(alternative)) {
+						if (isEarlyAccess(alternative)) {
+							if (isEarlyAccessEnabled()) {
+								// always prefer EA connector when EA available
+								toInstall = alternative;
+							}
+							// but never use EA connector when EA not enabled
+						} else if (toInstall == null) /*no better connector so far*/ {
+							toInstall = alternative;
+						}
+					}
+				}
+			}
+		}
+		return toInstall;
 	}
 	
 
@@ -227,14 +290,114 @@ public class JBossDiscoveryUi {
 	 * Installed the specified connectors by id. The visibility/availability of the connectors
 	 * takes into account the state of discovery (EA enabled, not installable connectors...)
 	 * @param connectorIds
+	 * @param interactive whether user is asked to choose when multiple flavours of same connector exist
 	 * @param context
 	 */
-	public static boolean installByIds(Collection<String> connectorIds, IRunnableContext context) {
-		Collection<ConnectorDescriptor> connectorsToInstall = resolveToConnectors(connectorIds, context);
+	public static boolean installByIds(Collection<String> connectorIds, boolean interactive, IRunnableContext context) {
+		Collection<ConnectorDescriptor> connectorsToInstall = resolveToConnectors(connectorIds, interactive, context);
 		if (connectorsToInstall == null || connectorsToInstall.size() != connectorIds.size()) {
 			return false;
 		}
 		return install(connectorsToInstall, context);
+	}
+	
+	public static Image computeIconImage(AbstractDiscoverySource discoverySource, Icon icon, int dimension, boolean fallback) {
+		String imagePath;
+		switch (dimension) {
+		case 64:
+			imagePath = icon.getImage64();
+			if (imagePath != null || !fallback) {
+				break;
+			}
+		case 48:
+			imagePath = icon.getImage48();
+			if (imagePath != null || !fallback) {
+				break;
+			}
+		case 32:
+			imagePath = icon.getImage32();
+			break;
+		default:
+			throw new IllegalArgumentException();
+		}
+		if (imagePath != null && imagePath.length() > 0) {
+			URL resource = discoverySource.getResource(imagePath);
+			if (resource != null) {
+				ImageDescriptor descriptor = ImageDescriptor.createFromURL(resource);
+				Image image = descriptor.createImage();
+				if (image != null) {
+					return image;
+				}
+			}
+		}
+		return null;
+	}
+
+	public static void hookTooltip(final Control parent, final Widget tipActivator, final Control exitControl,
+			final Control titleControl, AbstractDiscoverySource source, Overview overview, Image image) {
+		final OverviewToolTip toolTip = new OverviewToolTip(parent, source, overview, image);
+		Listener listener = new Listener() {
+			public void handleEvent(Event event) {
+				switch (event.type) {
+				case SWT.MouseHover:
+					toolTip.show(titleControl);
+					break;
+				case SWT.Dispose:
+				case SWT.MouseWheel:
+					toolTip.hide();
+					break;
+				}
+	
+			}
+		};
+		tipActivator.addListener(SWT.Dispose, listener);
+		tipActivator.addListener(SWT.MouseWheel, listener);
+		if (image != null) {
+			tipActivator.addListener(SWT.MouseHover, listener);
+		}
+		Listener selectionListener = new Listener() {
+			public void handleEvent(Event event) {
+				toolTip.show(titleControl);
+			}
+		};
+		tipActivator.addListener(SWT.Selection, selectionListener);
+		Listener exitListener = new Listener() {
+			public void handleEvent(Event event) {
+				switch (event.type) {
+				case SWT.MouseWheel:
+					toolTip.hide();
+					break;
+				case SWT.MouseExit:
+					/*
+					 * Check if the mouse exit happened because we move over the tooltip
+					 */
+					Rectangle containerBounds = exitControl.getBounds();
+					Point displayLocation = exitControl.getParent().toDisplay(containerBounds.x, containerBounds.y);
+					containerBounds.x = displayLocation.x;
+					containerBounds.y = displayLocation.y;
+					if (containerBounds.contains(Display.getCurrent().getCursorLocation())) {
+						break;
+					}
+					toolTip.hide();
+					break;
+				}
+			}
+		};
+		hookRecursively(exitControl, exitListener);
+	}
+	
+	private static void hookRecursively(Control control, Listener listener) {
+		control.addListener(SWT.Dispose, listener);
+		control.addListener(SWT.MouseHover, listener);
+		control.addListener(SWT.MouseMove, listener);
+		control.addListener(SWT.MouseExit, listener);
+		control.addListener(SWT.MouseDown, listener);
+		control.addListener(SWT.MouseWheel, listener);
+		if (control instanceof Composite) {
+			for (Control child : ((Composite) control).getChildren()) {
+				hookRecursively(child, listener);
+			}
+		}
 	}
 
 }

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/OverviewToolTip.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/OverviewToolTip.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
  *******************************************************************************/
-package org.jboss.tools.central.editors.xpl;
+package org.jboss.tools.discovery.core.internal.connectors;
 
 import java.net.URL;
 

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/P2CachedRepoUtil.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/P2CachedRepoUtil.java
@@ -1,4 +1,4 @@
-package org.jboss.tools.central.editors.xpl;
+package org.jboss.tools.discovery.core.internal.connectors;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -15,7 +15,7 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
 import org.eclipse.ui.PlatformUI;
-import org.jboss.tools.central.JBossCentralActivator;
+import org.jboss.tools.discovery.core.internal.DiscoveryActivator;
 
 public class P2CachedRepoUtil {
 
@@ -41,15 +41,15 @@ public class P2CachedRepoUtil {
 				repo = metadataManager.loadRepository(new URI(connector.getSiteUrl()), new NullProgressMonitor());
 				cachedRepo.put(connector.getSiteUrl(), repo);
 			} catch (ProvisionException ex) {
-				JBossCentralActivator.getDefault().getLog().log(new Status(
+				DiscoveryActivator.getDefault().getLog().log(new Status(
 						IStatus.ERROR,
-						JBossCentralActivator.PLUGIN_ID,
+						DiscoveryActivator.PLUGIN_ID,
 						ex.getMessage(),
 						ex));
 			} catch (URISyntaxException ex) {
-				JBossCentralActivator.getDefault().getLog().log(new Status(
+				DiscoveryActivator.getDefault().getLog().log(new Status(
 						IStatus.ERROR,
-						JBossCentralActivator.PLUGIN_ID,
+						DiscoveryActivator.PLUGIN_ID,
 						ex.getMessage(),
 						ex));
 			}

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/SelectConnectorDialog.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/SelectConnectorDialog.java
@@ -1,0 +1,99 @@
+/*************************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.jboss.tools.discovery.core.internal.connectors;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.window.IShellProvider;
+import org.eclipse.mylyn.internal.discovery.core.model.DiscoveryConnector;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.jboss.tools.discovery.core.internal.Messages;
+
+/**
+ * This dialog gives the opportunity to user to choose a single connector amongst a giveb list
+ * @author mistria
+ *
+ */
+public class SelectConnectorDialog extends Dialog {
+
+	private SortedSet<DiscoveryConnector> alternatives;
+	private ConnectorDescriptorItemUi selectedConnector;
+
+	protected SelectConnectorDialog(IShellProvider shellProvider, Collection<DiscoveryConnector> alternatives) {
+		super(shellProvider);
+		this.alternatives = new TreeSet<>(new Comparator<DiscoveryConnector>() {
+			// Show non-EA first
+			@Override
+			public int compare(DiscoveryConnector arg0, DiscoveryConnector arg1) {
+				if (arg1 == arg0) {
+					return 0;
+				}
+				if (JBossDiscoveryUi.isEarlyAccess(arg0)) {
+					return +1;
+				} else {
+					return -1;
+				}
+			}
+		});
+		this.alternatives.addAll(alternatives);
+	}
+	
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		getShell().setText(Messages.DiscoveryViewer_selectConnectorFlavor_title);
+		Composite res = new Composite(parent, SWT.NONE);
+		res.setLayout(new GridLayout(1, false));
+		
+		Label selectConnectorFlavorMessage = new Label(res, SWT.NONE);
+		selectConnectorFlavorMessage.setText(Messages.DiscoveryViewer_selectConnectorFlavor_description);
+		
+		boolean firstItem = true;
+		for (DiscoveryConnector connector : alternatives) {
+			// Would be good to reuse same UI as in Viewer there
+			final ConnectorDescriptorItemUi ui = new ConnectorDescriptorItemUi(null, connector, parent, parent.getBackground(), null, null, SWT.RADIO);
+			ui.addSelectionListener(new SelectionAdapter() {
+				@Override
+				public void widgetSelected(SelectionEvent e) {
+					if (((Button)e.widget).getSelection()) {
+						if (selectedConnector != null && e.data != selectedConnector) {
+							selectedConnector.setSelection(false);
+						}
+						if (ui.getSelection()) {
+							SelectConnectorDialog.this.selectedConnector = ui;
+						}
+					}
+				}
+			});
+			if (firstItem) {
+				firstItem = false;
+				ui.setSelection(true);
+				this.selectedConnector = ui;
+			}
+		}
+		return res;
+	}
+	
+	public DiscoveryConnector getSelectedConnector() {
+		return this.selectedConnector.getConnector();
+	}
+
+}

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/messages.properties
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/messages.properties
@@ -1,2 +1,17 @@
 UsageEventTypeInstallLabelDescription=Installing connector ID
 preparingUninstall=Prepare uninstall operation
+
+SoftwarePage_earlyAccessSection_Title=Early Access Features
+SoftwarePage_earlyAccessSection_message=Early Access features contain new functionality and/or fixes that are under development. \
+You are encouraged to use these features and to give feedback but be aware that these features are NOT officially supported, \
+NOT guaranteed to work correctly, and subject to removal from JBoss Central at any time, for any reason. Use them at your own risk!\n\
+\n\
+An Early Access update site will be added to the list of Available Software Sites, and may then be used to resolve dependencies \
+or provide newer versions of software when performing an update or install.\n\
+\n\
+I understand these conditions, and still want to enable Early Access features.
+SoftwarePage_nothingToInstall_title=Everything up-to-date
+SoftwarePage_nothingToInstall_description=All selected connectors are already installed and up-to-date.
+DiscoveryViewer_selectConnectorFlavor_description=The selected features exists in multiple forms, with different support level. Please choose which one you want to install/update.
+DiscoveryViewer_selectConnectorFlavor_title=Select extension flavor
+DiscoveryViewer_Certification_Label0=by {0}, {1}, <a>{2}</a>

--- a/examples/plugins/org.jboss.tools.project.examples/src/org/jboss/tools/project/examples/internal/fixes/PluginFixUIHandler.java
+++ b/examples/plugins/org.jboss.tools.project.examples/src/org/jboss/tools/project/examples/internal/fixes/PluginFixUIHandler.java
@@ -40,7 +40,7 @@ public class PluginFixUIHandler extends AbstractUIHandler {
 		if (!fix.isSatisfied() && fix instanceof PluginFix) {
 			PluginFix pluginFix = (PluginFix) fix;
 			Collection<String> connectorIds = pluginFix.getConnectorIDs();
-			if (!JBossDiscoveryUi.installByIds(connectorIds, context)) {
+			if (!JBossDiscoveryUi.installByIds(connectorIds, true, context)) {
 				ProjectExamplesActivator.log("Could not install requested connectors"); //$NON-NLS-1$
 			}
 		}


### PR DESCRIPTION
- Early Access connectors are shown by default (when no other version
  exists)
- When connector exists in regular and EA version, show regular version,
  then ask user at install which one they actually want to install
- Move control and overview on Early Access to an installation page,
  accessible from Software/Update page
