### PR TITLE
JBIDE-21027: Avoid presenting EA connector to wizards when EA isn't on

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/Messages.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/Messages.java
@@ -50,6 +50,11 @@ public class Messages extends NLS {
 	public static String visualEditorFaqLink;
 	
 	public static String usageEventBrowserLabelDescription;
+	
+	public static String additionalSoftwareRequired_title;
+	public static String additionalSoftwareRequired_message;
+	public static String unableToInstallConnectors_title;
+	public static String unableToInstallConnectors_message;
 
 	static {
 		// initialize resource bundle

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
@@ -82,6 +82,7 @@ import org.jboss.tools.central.actions.OpenWithBrowserHandler;
 import org.jboss.tools.central.editors.xpl.TextSearchControl;
 import org.jboss.tools.central.installation.InstallationChecker;
 import org.jboss.tools.central.preferences.PreferenceKeys;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
 
 /**
  * 
@@ -487,7 +488,7 @@ public class JBossCentralEditor extends SharedHeaderFormEditor {
 				final IPropertyChangeListener updateTitleOnEAChange = new IPropertyChangeListener() {
 					@Override
 					public void propertyChange(final PropertyChangeEvent event) {
-						if (event.getProperty().equals(PreferenceKeys.ENABLE_EARLY_ACCESS)) {
+						if (event.getProperty().equals(JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS)) {
 							if (heading.isDisposed()) {
 								return;
 							}
@@ -591,7 +592,7 @@ public class JBossCentralEditor extends SharedHeaderFormEditor {
 			}
 			titleLabel.setForeground(foreground);
 
-			boolean isEarlyAccessEnabled = JBossCentralActivator.getDefault().getPreferences().getBoolean(PreferenceKeys.ENABLE_EARLY_ACCESS, PreferenceKeys.ENABLE_EARLY_ACCESS_DEFAULT_VALUE);
+			boolean isEarlyAccessEnabled = JBossDiscoveryUi.isEarlyAccessEnabled();
 			boolean showEarlyAccessInstalled = this.installChecker != null && this.installChecker.hasEarlyAccess();
 			String title = "Welcome to JBoss";
 			String earlyAccessSuffix = "(Early Access ";

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/SoftwarePage.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/SoftwarePage.java
@@ -151,7 +151,7 @@ public class SoftwarePage extends AbstractJBossCentralPage implements IRunnableC
 	    discoveryViewer = new DiscoveryViewer(pageBook, this);
 	    discoveryViewer.addUserFilter(new InstalledFilter(), Messages.DiscoveryViewer_Hide_installed, true);
 		this.earlyAccessFilter = new EarlyAccessFilter();
-	    if (!JBossCentralActivator.getDefault().getPreferences().getBoolean(PreferenceKeys.ENABLE_EARLY_ACCESS, PreferenceKeys.ENABLE_EARLY_ACCESS_DEFAULT_VALUE)) {
+	    if (!JBossDiscoveryUi.isEarlyAccessEnabled()) {
 	    	discoveryViewer.addSystemFilter(this.earlyAccessFilter);
 	    }
 	    discoveryViewer.addSystemFilter(new EarlyAccessOrMostRecentVersionFilter());
@@ -230,7 +230,7 @@ public class SoftwarePage extends AbstractJBossCentralPage implements IRunnableC
 	    
 	    earlyAccessButton = toolkit.createButton(selectionButtonsComposite, Messages.DiscoveryViewer_Enable_EarlyAccess, SWT.CHECK);
 	    earlyAccessButton.setLayoutData(new GridData(SWT.END, SWT.DEFAULT, true, false));
-	    earlyAccessButton.setSelection(JBossCentralActivator.getDefault().getPreferences().getBoolean(PreferenceKeys.ENABLE_EARLY_ACCESS, PreferenceKeys.ENABLE_EARLY_ACCESS_DEFAULT_VALUE));
+	    earlyAccessButton.setSelection(JBossDiscoveryUi.isEarlyAccessEnabled());
 	    earlyAccessButton.addSelectionListener(new SelectionAdapter() {
 	    	@Override
 	    	public void widgetSelected(SelectionEvent e) {
@@ -511,7 +511,7 @@ public class SoftwarePage extends AbstractJBossCentralPage implements IRunnableC
 	private void handleEarlyAccessChanged(final Button checkbox) {
 		if (checkbox.getSelection()) {
 			if (MessageDialog.openQuestion(getEditorSite().getShell(),Messages.SoftwarePage_earlyAccessSection_Title, Messages.SoftwarePage_earlyAccessSection_message)) {
-				JBossCentralActivator.getDefault().getPreferences().putBoolean(PreferenceKeys.ENABLE_EARLY_ACCESS, true);
+				DiscoveryActivator.getDefault().getPreferences().putBoolean(JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS, true);
 				SoftwarePage.this.discoveryViewer.removeSystemFilter(SoftwarePage.this.earlyAccessFilter);
 			} else {
 				checkbox.setSelection(false);
@@ -555,7 +555,7 @@ public class SoftwarePage extends AbstractJBossCentralPage implements IRunnableC
 				}
 			}
 			
-			JBossCentralActivator.getDefault().getPreferences().putBoolean(PreferenceKeys.ENABLE_EARLY_ACCESS, false);
+			DiscoveryActivator.getDefault().getPreferences().putBoolean(JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS, false);
 			SoftwarePage.this.discoveryViewer.addSystemFilter(SoftwarePage.this.earlyAccessFilter);
 		}
 		SoftwarePage.this.discoveryViewer.updateFilters();

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/ConnectorDescriptorItemUi.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/ConnectorDescriptorItemUi.java
@@ -76,6 +76,7 @@ import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 import org.jboss.tools.central.JBossCentralActivator;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
 
 /**
  * Wraps a {@link DiscoveryConnector} in a UI element and provide additional
@@ -179,7 +180,7 @@ public class ConnectorDescriptorItemUi implements PropertyChangeListener, Runnab
 				ConnectorDescriptorItemUi.this.discoveryViewer.showConnectorControl(ConnectorDescriptorItemUi.this);
 			}
 		});
-		this.isRealConnector = (connector.getCertificationId() == null || !connector.getCertificationId().toLowerCase().contains("notavailable"));
+		this.isRealConnector = JBossDiscoveryUi.isInstallableConnector(connector);
 		checkbox.setVisible(this.isRealConnector);
 		checkbox.setEnabled(this.isRealConnector);
 

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/DiscoveryViewer.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/DiscoveryViewer.java
@@ -124,6 +124,7 @@ import org.jboss.tools.central.editors.xpl.filters.EarlyAccessOrMostRecentVersio
 import org.jboss.tools.central.editors.xpl.filters.FiltersSelectionDialog;
 import org.jboss.tools.central.editors.xpl.filters.UserFilterEntry;
 import org.jboss.tools.discovery.core.internal.connectors.DiscoveryUtil;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 
@@ -1376,7 +1377,7 @@ public class DiscoveryViewer extends Viewer {
 		// TODO allow to plug computation of color externally, similar to addFilter
 		// something like addConditionalStyle(ConnectorDiscovery)
 		// TODO color is also defined in JBossCentralEditor 
-		if (EarlyAccessFilter.isEarlyAccess(connector)) {
+		if (JBossDiscoveryUi.isEarlyAccess(connector)) {
 			return JFaceResources.getColorRegistry().get(JBossCentralEditor.COLOR_LIGHTYELLOW);
 		}
 		return res;

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/EarlyAccessFilter.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/EarlyAccessFilter.java
@@ -13,6 +13,7 @@ package org.jboss.tools.central.editors.xpl.filters;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
 
 /**
  * Filter that excludes connector which have certifacte id containing
@@ -28,12 +29,7 @@ public class EarlyAccessFilter extends ViewerFilter {
 			return true;
 		}
 		ConnectorDescriptor connector = (ConnectorDescriptor)element;
-		return !isEarlyAccess(connector);
-	}
-
-	public static boolean isEarlyAccess(ConnectorDescriptor connector) {
-		String cert = connector.getCertificationId();
-		return cert != null && cert.toLowerCase().contains("earlyaccess");
+		return !JBossDiscoveryUi.isEarlyAccess(connector);
 	}
 
 }

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/EarlyAccessOrMostRecentVersionFilter.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/xpl/filters/EarlyAccessOrMostRecentVersionFilter.java
@@ -31,6 +31,7 @@ import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
 import org.jboss.tools.central.editors.xpl.ConnectorDescriptorItemUi;
 import org.jboss.tools.central.editors.xpl.DiscoveryViewer;
+import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
 
 /**
  * Hides all visible {@link ConnectorDescriptor} that have another visible
@@ -134,10 +135,10 @@ public class EarlyAccessOrMostRecentVersionFilter extends ViewerFilter {
 			if (item1 == item2) {
 				return 0;
 			}
-			if (EarlyAccessFilter.isEarlyAccess(item1.getConnector()) && !EarlyAccessFilter.isEarlyAccess(item2.getConnector())) {
+			if (JBossDiscoveryUi.isEarlyAccess(item1.getConnector()) && !JBossDiscoveryUi.isEarlyAccess(item2.getConnector())) {
 				return -1;
 			}
-			if (EarlyAccessFilter.isEarlyAccess(item2.getConnector()) && !EarlyAccessFilter.isEarlyAccess(item1.getConnector())) {
+			if (JBossDiscoveryUi.isEarlyAccess(item2.getConnector()) && !JBossDiscoveryUi.isEarlyAccess(item1.getConnector())) {
 				return 1;
 			}
 			

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/messages.properties
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/messages.properties
@@ -56,3 +56,11 @@ visualEditorFaq=See JBoss Tools Visual Editor FAQ
 visualEditorFaqLink=http://tools.jboss.org/documentation/faq/visualeditor.html
 
 usageEventBrowserLabelDescription=Specifies which browser was used for JBoss Tools Central
+
+additionalSoftwareRequired_title=Additional features
+additionalSoftwareRequired_message=The required features to use this wizard need to be installed. Do you want to proceed?
+
+unableToInstallConnectors_title=Failed to install necessary software.
+unableToInstallConnectors_message=The additional software required for this wizard to perform correctly could not be installed.\n\
+Please check the log for more details. 
+

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/preferences/PreferenceKeys.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/preferences/PreferenceKeys.java
@@ -15,6 +15,4 @@ public interface PreferenceKeys {
 	public static final String SHOW_JBOSS_CENTRAL_ON_STARTUP = "showJBossCentralOnStartup";
 	public static final boolean SHOW_JBOSS_CENTRAL_ON_STARTUP_DEFAULT_VALUE = true;
 	
-	public static final String ENABLE_EARLY_ACCESS = "enableEarlyAccess";
-	public static final boolean ENABLE_EARLY_ACCESS_DEFAULT_VALUE = false;
 }

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/DiscoveryActivator.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/DiscoveryActivator.java
@@ -12,6 +12,8 @@ package org.jboss.tools.discovery.core.internal;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
@@ -44,7 +46,7 @@ public class DiscoveryActivator extends AbstractUIPlugin {
 	private static final String CENTRAL_COMPONENT_NAME = "central"; //$NON-NLS-1$
 	private static final String INSTALL_ACTION = "install"; //$NON-NLS-1$
 	private UsageEventType installSoftwareEventType;
-
+	
 	/**
 	 * The constructor
 	 */
@@ -139,6 +141,11 @@ public class DiscoveryActivator extends AbstractUIPlugin {
 			logError(String.format("No URL set for discovery catalog. Property %s is missing!", DiscoveryActivator.JBOSS_DISCOVERY_DIRECTORY)); //$NON-NLS-1$
 		}
 		return directory;
+	}
+	
+	public IEclipsePreferences getPreferences() {
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(PLUGIN_ID);
+		return prefs;
 	}
 
 }

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/DiscoveryUtil.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/DiscoveryUtil.java
@@ -30,6 +30,7 @@ public class DiscoveryUtil {
 	
 	/**
 	 * Creates a new {@link ConnectorDiscovery} which looks for remote discovery sites first and falls back on locally defined connectors.
+	 * This will contain ALL discovery content, without filtering, so Early-Access is visible here when although it may not be enabled
 	 */
 	public static ConnectorDiscovery createConnectorDiscovery() {
 		String directoryUrl = DiscoveryActivator.getDefault().getJBossDiscoveryDirectory();

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/JBossDiscoveryUi.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/JBossDiscoveryUi.java
@@ -1,5 +1,5 @@
 /*************************************************************************************
- * Copyright (c) 2013-2014 Red Hat, Inc. and others.
+ * Copyright (c) 2013-2015 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials 
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,14 +12,23 @@ package org.jboss.tools.discovery.core.internal.connectors;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDescriptor;
+import org.eclipse.mylyn.internal.discovery.core.model.ConnectorDiscovery;
 import org.eclipse.mylyn.internal.discovery.core.model.DiscoveryFeedbackJob;
 import org.eclipse.mylyn.internal.discovery.ui.DiscoveryUi;
 import org.eclipse.mylyn.internal.discovery.ui.InstalledItem;
@@ -42,14 +51,41 @@ import org.jboss.tools.usage.event.UsageReporter;
 public class JBossDiscoveryUi {
 	
 	//private static final String MPC_CORE_PLUGIN_ID = "org.eclipse.epp.mpc.core"; //$NON-NLS-1$
+	
+	public static final class PreferenceKeys {
+		/**
+		 * If it's only for reading, use {@link JBossDiscoveryUi#isEarlyAccessEnabled()} instead
+		 */
+		public static final String ENABLE_EARLY_ACCESS = "enableEarlyAccess";
+		private static final boolean ENABLE_EARLY_ACCESS_DEFAULT_VALUE = false;
+	}
 
-	public static boolean install(List<ConnectorDescriptor> descriptors, IRunnableContext context) {
+	public static boolean isEarlyAccessEnabled() {
+		return DiscoveryActivator.getDefault().getPreferences().getBoolean(JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS, JBossDiscoveryUi.PreferenceKeys.ENABLE_EARLY_ACCESS_DEFAULT_VALUE);
+	}
+	
+	/**
+	 * Install the specified connectors.
+	 * @param descriptors the specified connectors. Those must have actual content to install.
+	 * @param context
+	 * @return true if installation performed successfully
+	 */
+	public static boolean install(Collection<ConnectorDescriptor> descriptors, IRunnableContext context) {
+		for (ConnectorDescriptor toInstall : descriptors) {
+			if (toInstall.getInstallableUnits() == null || toInstall.getInstallableUnits().isEmpty()) {
+				return false;
+			}
+		}
 		try {
 			IRunnableWithProgress runner = createInstallJob(descriptors);
-			context.run(true, true, runner);
+			if (context != null) {
+				context.run(true, true, runner);
+			} else {
+				runner.run(new NullProgressMonitor());
+			}
 
 			// update stats
-			new DiscoveryFeedbackJob(descriptors).schedule();
+			new DiscoveryFeedbackJob(descriptors instanceof List ? (List<ConnectorDescriptor>)descriptors : new ArrayList<>(descriptors)).schedule();
 			recordInstalled(descriptors);
 		} catch (InvocationTargetException e) {
 			IStatus status = new Status(IStatus.ERROR, DiscoveryActivator.PLUGIN_ID, NLS.bind(
@@ -103,11 +139,11 @@ public class JBossDiscoveryUi {
 	}
 	
 	
-	public static PrepareInstallProfileJob createInstallJob(List<ConnectorDescriptor> descriptors) {
+	public static PrepareInstallProfileJob createInstallJob(Collection<ConnectorDescriptor> descriptors) {
 		return new PrepareInstallProfileJob(descriptors);
 	}
 	
-	private static void recordInstalled(List<ConnectorDescriptor> descriptors) {
+	private static void recordInstalled(Collection<ConnectorDescriptor> descriptors) {
 		StringBuilder sb = new StringBuilder();
 		for (ConnectorDescriptor descriptor : descriptors) {
 			UsageEventType eventType = DiscoveryActivator.getDefault().getInstallSoftwareEventType();
@@ -125,6 +161,76 @@ public class JBossDiscoveryUi {
 		} catch (IOException e) {
 			// ignore
 		}
+	}
+
+	public static boolean isEarlyAccess(ConnectorDescriptor connector) {
+		String cert = connector.getCertificationId();
+		return cert != null && cert.toLowerCase().contains("earlyaccess");
+	}
+	
+	public static boolean isInstallableConnector(final ConnectorDescriptor connector) {
+		return connector.getCertificationId() == null || !connector.getCertificationId().toLowerCase().contains("notavailable");
+	}
+
+
+	/**
+	 * 
+	 * @param connectorsId
+	 * @param context
+	 * @return the set of resolved connector. In case a connector wasn't resolved, it's simply absent in the set, so you
+	 *         should check size or the output for completeness. 
+	 */
+	public static Collection<ConnectorDescriptor> resolveToConnectors(Collection<String> connectorsId, IRunnableContext context) {
+		Map<String, ConnectorDescriptor> res = new HashMap<>();
+		final ConnectorDiscovery catalog = DiscoveryUtil.createConnectorDiscovery();
+		try {
+			context.run(true, true, new IRunnableWithProgress() {
+				@Override
+				public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+					catalog.performDiscovery(monitor);
+				}
+			});
+		} catch (InterruptedException ex) {
+			DiscoveryActivator.getDefault().getLog().log(new Status(IStatus.ERROR, DiscoveryActivator.getDefault().getBundle().getSymbolicName(), ex.getMessage(), ex));
+		} catch (InvocationTargetException ex) {
+			DiscoveryActivator.getDefault().getLog().log(new Status(IStatus.ERROR, DiscoveryActivator.getDefault().getBundle().getSymbolicName(), ex.getMessage(), ex));
+		}
+		for (ConnectorDescriptor connector : catalog.getConnectors()) {
+			if (connectorsId.contains(connector.getId()) &&
+				connector.getInstallableUnits() != null &&
+				!connector.getInstallableUnits().isEmpty() &&
+				isInstallableConnector(connector)) {
+				if (isEarlyAccessEnabled() && isEarlyAccess(connector)) {
+					res.put(connector.getId(), connector);
+				} else if (!res.containsKey(connector.getId()) /*no early access so far*/) {
+					res.put(connector.getId(), connector);
+				}
+			}
+		}
+		if (res.size() != connectorsId.size()) {
+			Set<String> missingConnectoes = new HashSet<>(connectorsId);
+			missingConnectoes.removeAll(res.keySet());
+			DiscoveryActivator.getDefault().getLog().log(new Status(
+				IStatus.ERROR,
+				DiscoveryActivator.getDefault().getBundle().getSymbolicName(),
+				"Could not resolve the following connectorIds to catalog entries: " + missingConnectoes.toString())); //$NON-NLS-1$
+		}
+		return res.values();
+	}
+	
+
+	/**
+	 * Installed the specified connectors by id. The visibility/availability of the connectors
+	 * takes into account the state of discovery (EA enabled, not installable connectors...)
+	 * @param connectorIds
+	 * @param context
+	 */
+	public static boolean installByIds(Collection<String> connectorIds, IRunnableContext context) {
+		Collection<ConnectorDescriptor> connectorsToInstall = resolveToConnectors(connectorIds, context);
+		if (connectorsToInstall == null || connectorsToInstall.size() != connectorIds.size()) {
+			return false;
+		}
+		return install(connectorsToInstall, context);
 	}
 
 }

--- a/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/PrepareInstallProfileJob.java
+++ b/discovery/plugins/org.jboss.tools.discovery.core/src/org/jboss/tools/discovery/core/internal/connectors/PrepareInstallProfileJob.java
@@ -89,13 +89,13 @@ import org.eclipse.ui.PlatformUI;
  */
 public class PrepareInstallProfileJob extends AbstractInstallJob {
 
-	protected final List<ConnectorDescriptor> installableConnectors;
+	protected final Collection<ConnectorDescriptor> installableConnectors;
 
 	protected final ProvisioningUI provisioningUI;
 
 	protected Set<URI> repositoryLocations;
 
-	public PrepareInstallProfileJob(List<ConnectorDescriptor> installableConnectors) {
+	public PrepareInstallProfileJob(Collection<ConnectorDescriptor> installableConnectors) {
 		if (installableConnectors == null) {
 			throw new IllegalArgumentException();
 		}


### PR DESCRIPTION
This change moves most of Early Access logic a layer above (in the core
discovery part instead of Central UI). It makes the JBossDiscoveryUi the
reference class to use for anything that would like to trigger a user
controlled installation of connectors.