### PR TITLE
JBIDE-21673 JBoss Runtime Detection preference page throws StackOverflowError

### DIFF
--- a/maven/plugins/org.jboss.tools.maven.ui/src/org/jboss/tools/maven/ui/preferences/RemoteRepositoriesPreferencePage.java
+++ b/maven/plugins/org.jboss.tools.maven.ui/src/org/jboss/tools/maven/ui/preferences/RemoteRepositoriesPreferencePage.java
@@ -84,6 +84,7 @@ public class RemoteRepositoriesPreferencePage extends PreferencePage implements
 		// Nexus Repositories
 		Group group = new Group(composite, SWT.NONE);
 		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, false);
+		gd.widthHint = 100; //A dirty trick that keeps table from growing unlimitedly 
 		group.setLayoutData(gd);
 		layout = new GridLayout(2, false);
 		group.setLayout(layout);


### PR DESCRIPTION
Fixed unlimited expansion of Remote Repositories page,
similar to that in JBoss Runtime Detection (though in its case
no stack overflow happens).