### PR TITLE
JBIDE-22258: Remove dependency on e4 importer

### DIFF
--- a/central/features/org.jboss.tools.central.easymport.feature/feature.xml
+++ b/central/features/org.jboss.tools.central.easymport.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.central.easymport.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="4.4.0.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
@@ -20,13 +20,10 @@
    </license>
 
    <requires>
-     <import plugin="org.eclipse.e4.ui.importer"/>
      <!-- Those are in TP but not part of an included feature yet -->
-     <import plugin="org.eclipse.egit.ui.importer"/>
+     <import plugin="org.eclipse.egit.ui.smartimport"/>
      <import plugin="org.eclipse.e4.ui.importer.java"/>
      <import plugin="org.eclipse.e4.ui.importer.pde"/>
-     <import plugin="org.eclipse.wst.jsdt.ui.importer"/>
-     <import plugin="org.eclipse.m2e.importer"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
Smart Import is now part of M7 TP, so we do not need the e4 version any more.
Some bundles are now included in their "main" feature or bundle so we don't have to add an additional dependency to those.