### PR TITLE
JBIDE-21134: Remove reference to Playground Smart Import JEE

### DIFF
--- a/central/features/org.jboss.tools.central.easymport.feature/feature.xml
+++ b/central/features/org.jboss.tools.central.easymport.feature/feature.xml
@@ -26,11 +26,4 @@
      <import plugin="org.eclipse.e4.ui.importer.pde"/>
    </requires>
 
-   <plugin
-         id="org.jboss.tools.playground.easymport.jee"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-         
 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,6 @@
 			<url>${jbosstools-vpe-site}</url>
 		</repository>
 		<repository>
-			<id>jbosstools-playground</id>
-			<layout>p2</layout>
-			<url>${jbosstools-playground-site}</url>
-		</repository>
-		<repository>
 			<id>thym</id>
 			<layout>p2</layout>
 			<url>http://download.jboss.org/jbosstools/updates/requirements/thym/0.3.0-SNAPSHOT-201504101636</url>


### PR DESCRIPTION
Its content has moved directly to jax-rs and hibernate components at the
moment, and patches have been submitted upstream at Eclipse.org