### PR TITLE
JBDS-4195: Remove Software/Update page on RPM installs.

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
@@ -199,7 +199,7 @@ public class JBossCentralEditor extends SharedHeaderFormEditor {
 			setPageImage(index, gettingStartedImage);
 
 			String applicationName = JBossToolsUsageActivator.getDefault().getJBossToolsEclipseEnvironment().getEclipseUserAgent().getApplicationName();
-			if (!applicationName.contains("|")) { // Most likely RPM
+			if (!applicationName.contains("|Devstudio")) { // Installed via RPM. Do not add "Software/Update" tab to Central. See https://issues.jboss.org/browse/JBDS-4195
 				softwarePage = new SoftwarePage(this);
 				index = addPage(softwarePage);
 				if (softwareImage == null) {

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
@@ -207,6 +207,8 @@ public class JBossCentralEditor extends SharedHeaderFormEditor {
 							"/icons/software.png").createImage();
 				}
 				setPageImage(index, softwareImage);
+			} else {
+				JBossCentralActivator.logWarning("JBoss Tools installed via a package manager. \"Software/Update\" is disabled for Red Hat Central. Detected application name with installed packages: \"" + applicationName + "\"");
 			}
 		} catch (PartInitException e) {
 			JBossCentralActivator.log(e, "Error adding page");

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/JBossCentralEditor.java
@@ -77,6 +77,7 @@ import org.jboss.tools.central.actions.OpenWithBrowserHandler;
 import org.jboss.tools.central.editors.xpl.TextSearchControl;
 import org.jboss.tools.central.installation.InstallationChecker;
 import org.jboss.tools.discovery.core.internal.connectors.JBossDiscoveryUi;
+import org.jboss.tools.usage.internal.JBossToolsUsageActivator;
 
 /**
  * 
@@ -197,13 +198,16 @@ public class JBossCentralEditor extends SharedHeaderFormEditor {
 			}
 			setPageImage(index, gettingStartedImage);
 
-			softwarePage = new SoftwarePage(this);
-			index = addPage(softwarePage);
-			if (softwareImage == null) {
-				softwareImage = JBossCentralActivator.getImageDescriptor(
-						"/icons/software.png").createImage();
+			String applicationName = JBossToolsUsageActivator.getDefault().getJBossToolsEclipseEnvironment().getEclipseUserAgent().getApplicationName();
+			if (!applicationName.contains("|")) { // Most likely RPM
+				softwarePage = new SoftwarePage(this);
+				index = addPage(softwarePage);
+				if (softwareImage == null) {
+					softwareImage = JBossCentralActivator.getImageDescriptor(
+							"/icons/software.png").createImage();
+				}
+				setPageImage(index, softwareImage);
 			}
-			setPageImage(index, softwareImage);
 		} catch (PartInitException e) {
 			JBossCentralActivator.log(e, "Error adding page");
 		}

--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/RefreshDiscoveryJob.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/RefreshDiscoveryJob.java
@@ -45,7 +45,10 @@ public class RefreshDiscoveryJob extends Job {
 			}
 		});
 		if (editors[0] != null) {
-			editors[0].getSoftwarePage().getDiscoveryViewer().updateDiscovery();
+			SoftwarePage softwarePage = editors[0].getSoftwarePage();
+			if (softwarePage != null) {
+				softwarePage.getDiscoveryViewer().updateDiscovery();
+			}
 		}
 		return Status.OK_STATUS;
 	}


### PR DESCRIPTION
RPM installs are currently not fully p2-able. Don't present the
Software/Update page when installed from RPM as there are big risks
of crashing user installation.