### PR TITLE
JBIDE-23759 - Avoid silent NPE

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedHtmlPage.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/editors/GettingStartedHtmlPage.java
@@ -136,7 +136,7 @@ public class GettingStartedHtmlPage extends AbstractJBossCentralPage implements 
 	private Collection<FavoriteItem> favorites;
 
 	private Map<String, ProjectExample> examples;
-	private Map<String, ProxyWizard> displayedWizardsMap;
+	private Map<String, ProxyWizard> displayedWizardsMap = new HashMap<>();
 	private RefreshBuzzJobChangeListener buzzlistener;
 	private boolean showOnStartup;
 	


### PR DESCRIPTION
if the Job which is initializing the Map has not finished, a NPE is
thrown and caught. Initializing with an empty Map avoids this NPE