### PR TITLE
JBIDE-24133 org.jboss.tools.runtime.reddeer...

### DIFF
--- a/central/features/org.jboss.tools.central.test.feature/feature.xml
+++ b/central/features/org.jboss.tools.central.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.central.test.feature"
       label="%featureName"
-      version="2.1.3.qualifier"
+      version="2.1.100.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
 	  license-feature-version="0.0.0">

--- a/central/features/org.jboss.tools.central.test.feature/pom.xml
+++ b/central/features/org.jboss.tools.central.test.feature/pom.xml
@@ -9,5 +9,6 @@
 	</parent>
 	<groupId>org.jboss.central.features</groupId>
 	<artifactId>org.jboss.tools.central.test.feature</artifactId>
+	<version>2.1.100-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/central/test-framework/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
+++ b/central/test-framework/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
@@ -8,9 +8,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.jboss.reddeer.go;bundle-version="[1.2.0,2.0.0)",
  org.junit;bundle-version="4.8.1",
- org.jboss.tools.runtime.reddeer;bundle-version="[3.2.3,3.3.0)",
+ org.jboss.tools.runtime.reddeer;bundle-version="[3.3.0,3.4.0)",
  org.jboss.tools.maven.reddeer;bundle-version="[1.8.3,1.9.0)",
- org.jboss.ide.eclipse.as.reddeer;bundle-version="[3.2.3,3.3.0)",
+ org.jboss.ide.eclipse.as.reddeer;bundle-version="[3.3.0,3.4.0)",
  org.jboss.tools.project.examples,
  org.apache.commons.io;bundle-version="2.0.1"
 Bundle-ActivationPolicy: lazy

--- a/central/test-framework/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
+++ b/central/test-framework/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.go;bundle-version="[1.2.0,2.0.0)",
  org.junit;bundle-version="4.8.1",
  org.jboss.tools.runtime.reddeer;bundle-version="[3.3.0,3.4.0)",
- org.jboss.tools.maven.reddeer;bundle-version="[1.8.3,1.9.0)",
+ org.jboss.tools.maven.reddeer;bundle-version="[1.8.100,1.9.0)",
  org.jboss.ide.eclipse.as.reddeer;bundle-version="[3.3.0,3.4.0)",
  org.jboss.tools.project.examples,
  org.apache.commons.io;bundle-version="2.0.1"

--- a/central/test-framework/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
+++ b/central/test-framework/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Central Reddeer
 Bundle-SymbolicName: org.jboss.tools.central.reddeer
-Bundle-Version: 2.1.3.qualifier
+Bundle-Version: 2.1.100.qualifier
 Bundle-Activator: org.jboss.tools.central.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/central/test-framework/org.jboss.tools.central.reddeer/pom.xml
+++ b/central/test-framework/org.jboss.tools.central.reddeer/pom.xml
@@ -9,5 +9,6 @@
 	</parent>
 	<groupId>org.jboss.tools.central</groupId>
 	<artifactId>org.jboss.tools.central.reddeer</artifactId>
+	<version>2.1.100-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/maven/features/org.jboss.tools.maven.test.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.test.feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.jboss.tools.maven.test.feature" label="%featureName" version="1.8.3.qualifier" provider-name="%featureProvider"
+<feature id="org.jboss.tools.maven.test.feature" label="%featureName" version="1.8.100.qualifier" provider-name="%featureProvider"
     license-feature="org.jboss.tools.foundation.license.feature"
 	license-feature-version="0.0.0">
 

--- a/maven/features/org.jboss.tools.maven.test.feature/pom.xml
+++ b/maven/features/org.jboss.tools.maven.test.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.maven.features</groupId>
 	<artifactId>org.jboss.tools.maven.test.feature</artifactId>
+	<version>1.8.100-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/maven/test-framework/org.jboss.tools.maven.reddeer/META-INF/MANIFEST.MF
+++ b/maven/test-framework/org.jboss.tools.maven.reddeer/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Maven Reddeer
 Bundle-SymbolicName: org.jboss.tools.maven.reddeer;singleton:=true
-Bundle-Version: 1.8.3.qualifier
+Bundle-Version: 1.8.100.qualifier
 Bundle-Activator: org.jboss.tools.maven.reddeer.Activator
 Require-Bundle:  org.jboss.reddeer.go;bundle-version="[1.2.0,2.0.0)",
- org.jboss.tools.runtime.reddeer;bundle-version="[3.2.3,3.3.0)",
+ org.jboss.tools.runtime.reddeer;bundle-version="[3.3.0,3.4.0)",
  org.jboss.tools.runtime.ui;bundle-version="3.0.0",
  org.jboss.tools.foundation.ui;bundle-version="1.1.0"
 Export-Package: 

--- a/maven/test-framework/org.jboss.tools.maven.reddeer/pom.xml
+++ b/maven/test-framework/org.jboss.tools.maven.reddeer/pom.xml
@@ -10,5 +10,6 @@
 	
 	<groupId>org.jboss.tools.maven</groupId>
 	<artifactId>org.jboss.tools.maven.reddeer</artifactId>
+	<version>1.8.100-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
JBIDE-24133 org.jboss.tools.runtime.reddeer and org.jboss.ide.eclipse.as.reddeer are bumped to 3.3.0 in oxygen stream so increment in org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF too

Signed-off-by: nickboldt <nboldt@redhat.com>