### PR TITLE
JBDS-4495 org.jboss.tools.maven.cdi.feature...

### DIFF
--- a/maven/features/org.jboss.tools.maven.cdi.feature/feature.properties
+++ b/maven/features/org.jboss.tools.maven.cdi.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010-2014 Red Hat, Inc. and others.
+# Copyright (c) 2010-2017 Red Hat, Inc. and others.
 # All rights reserved. This program and the accompanying materials 
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ providerName=JBoss by Red Hat
 description=Enables CDI tooling on Maven projects that depends or contain CDI specific artifacts. 
 
 # "copyright" property - text of the "Feature Update Copyright"
-copyright=Copyright (c) 2010-2014 Red Hat, Inc. and others.\n\
+copyright=Copyright (c) 2010-2017 Red Hat, Inc. and others.\n\
 All rights reserved. This program and the accompanying materials\n\
 are made available under the terms of the Eclipse Public License v1.0\n\
 which accompanies this distribution, and is available at\n\

--- a/maven/features/org.jboss.tools.maven.test.feature/feature.properties
+++ b/maven/features/org.jboss.tools.maven.test.feature/feature.properties
@@ -6,7 +6,7 @@ featureProvider=JBoss by Red Hat
 description=JBoss Tools - Tests - Maven
 
 # "copyright" property - text of the "Feature Update Copyright"
-copyright=Copyright (c) 2010-2014 Red Hat, Inc. and others.\n\
+copyright=Copyright (c) 2010-2017 Red Hat, Inc. and others.\n\
 All rights reserved. This program and the accompanying materials\n\
 are made available under the terms of the Eclipse Public License v1.0\n\
 which accompanies this distribution, and is available at\n\

--- a/maven/tests/org.jboss.tools.maven.configurators.tests/src/org/jboss/tools/maven/cdi/BeansXmlQuickPeekTest.java
+++ b/maven/tests/org.jboss.tools.maven.configurators.tests/src/org/jboss/tools/maven/cdi/BeansXmlQuickPeekTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2014 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,


### PR DESCRIPTION
JBDS-4495 org.jboss.tools.maven.cdi.feature is not yet deprecated so update the copyright date from 2014 to show it's - ahem - still being developed

Signed-off-by: nickboldt <nboldt@redhat.com>