### PR TITLE
JBDS-4571 patch to make jboss central work on unpatched swt webkit2

### DIFF
--- a/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/internal/browser/VersionedBrowser.java
+++ b/central/plugins/org.jboss.tools.central/src/org/jboss/tools/central/internal/browser/VersionedBrowser.java
@@ -32,8 +32,7 @@ public class VersionedBrowser extends Browser {
 	public VersionedBrowser(Composite parent, int style) {
 		super(parent, style);
 		//TODO Check Project Spartan / Edge
-		String browserScript =
-				   "var ua = navigator.userAgent,tem,M=ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\\/))\\/?\\s*(\\d+)/i) || [];" +  //$NON-NLS-1$
+		execute("var ua = navigator.userAgent,tem,M=ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\\/))\\/?\\s*(\\d+)/i) || [];" +  //$NON-NLS-1$
 				   "if(/trident/i.test(M[1])){" + //$NON-NLS-1$
 				   		"tem=/\\brv[ :]+(\\d+)/g.exec(ua) || [];" +  //$NON-NLS-1$
 				   		"return 'IE '+ '_' + (tem[1]||'');" + //$NON-NLS-1$
@@ -46,9 +45,8 @@ public class VersionedBrowser extends Browser {
 				   	"M=M[2]? [M[1], M[2]]: [navigator.appName, navigator.appVersion, '-?'];" + //$NON-NLS-1$
 				   	"if((tem=ua.match(/version\\/(\\d+)/i))!=null) {" + //$NON-NLS-1$
 				   		"M.splice(1,1,tem[1]);" + //$NON-NLS-1$
-				   	"}"+ //$NON-NLS-1$
-				   	"return M[0] + '_' + M[1];" ; //$NON-NLS-1$
-		String result = (String) evaluate(browserScript);
+				   	"}"); //$NON-NLS-1$
+		String result = (String) evaluate("return M[0] + '_' + M[1];"); //$NON-NLS-$1	
 
 		if (result != null) {
 			name = result.substring(0, result.indexOf("_")); //$NON-NLS-1$


### PR DESCRIPTION
Note:
- patch is untested (I don't have a setup for jbosstools-central development). 
- Could someone verify that this doesn't break the Central homepage?

To verify before/after, you'll need a setup that has webkit2. E.g Fedora25/26.
Launch dev studio with webkit2:
export SWT_WEBKIT2=1
eclipse

launch Central homepage, inspect that page still loads properly.