### PR TITLE
JBDS-4681 switch to correct fuse central...

### DIFF
--- a/examples/features/org.jboss.tools.project.examples.feature/feature.xml
+++ b/examples/features/org.jboss.tools.project.examples.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.project.examples.feature"
       label="%featureName"
-      version="3.1.102.qualifier"
+      version="3.1.103.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.project.examples"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/examples/features/org.jboss.tools.project.examples.feature/pom.xml
+++ b/examples/features/org.jboss.tools.project.examples.feature/pom.xml
@@ -9,5 +9,6 @@
 	</parent>
 	<groupId>org.jboss.tools.examples.features</groupId>
 	<artifactId>org.jboss.tools.project.examples.feature</artifactId>
+	<version>3.1.103-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/examples/plugins/org.jboss.tools.project.examples/META-INF/MANIFEST.MF
+++ b/examples/plugins/org.jboss.tools.project.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.project.examples;singleton:=true
-Bundle-Version: 3.1.102.qualifier
+Bundle-Version: 3.1.103.qualifier
 Bundle-Activator: org.jboss.tools.project.examples.internal.ProjectExamplesActivator
 Bundle-Vendor: %BundleVendor
 Require-Bundle: org.eclipse.ui,

--- a/examples/plugins/org.jboss.tools.project.examples/pom.xml
+++ b/examples/plugins/org.jboss.tools.project.examples/pom.xml
@@ -9,5 +9,6 @@
 	</parent>
 	<groupId>org.jboss.tools.examples.plugins</groupId>
 	<artifactId>org.jboss.tools.project.examples</artifactId>
+	<version>3.1.103-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/examples/plugins/org.jboss.tools.project.examples/src/org/jboss/tools/project/examples/internal/model/RequirementModelUtil.java
+++ b/examples/plugins/org.jboss.tools.project.examples/src/org/jboss/tools/project/examples/internal/model/RequirementModelUtil.java
@@ -192,7 +192,7 @@ public class RequirementModelUtil {
 		properties.put("id", "org.fusesource.ide.tooling");
 		properties.put("versions", "1.0.0");
 		properties.put("description", "This example works best with JBoss Fuse Development Tools");
-		properties.put("connectorIds", "jboss.integration-stack.bundle.fuse");
+		properties.put("connectorIds", "org.fusesource.ide");
 		req.setProperties(properties);
 		return req;
 	}


### PR DESCRIPTION
JBDS-4681 switch to correct fuse central connector ID org.fusesource.ide instead of hella-old non-existant one, jboss.integration-stack.bundle.fuse

Signed-off-by: nickboldt <nboldt@redhat.com>