### PR TITLE
JBIDE-24976

### DIFF
--- a/maven/test-framework/org.jboss.tools.maven.reddeer/src/org/jboss/tools/maven/reddeer/wizards/MavenProjectWizardSecondPage.java
+++ b/maven/test-framework/org.jboss.tools.maven.reddeer/src/org/jboss/tools/maven/reddeer/wizards/MavenProjectWizardSecondPage.java
@@ -11,27 +11,38 @@
 package org.jboss.tools.maven.reddeer.wizards;
 
 import org.eclipse.reddeer.jface.wizard.WizardPage;
+import org.eclipse.reddeer.swt.api.TableItem;
 import org.eclipse.reddeer.swt.condition.TableHasRows;
 import org.eclipse.reddeer.swt.impl.combo.DefaultCombo;
 import org.eclipse.reddeer.swt.impl.table.DefaultTable;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
+import org.jboss.tools.maven.reddeer.wizards.matchers.ArtifactIdAndGroupIdMatcher;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.core.reference.ReferencedComposite;
+
+import java.util.List;
 
 public class MavenProjectWizardSecondPage extends WizardPage{
 	
 	public MavenProjectWizardSecondPage(ReferencedComposite referencedComposite) {
 		super(referencedComposite);
 	}
+	
+	public void selectArchetype(String catalog, final String archetype){
+		selectArchetype(catalog, archetype, null);
+	}
 
-	public void selectArchetype(String catalog, String archetype){
+	public void selectArchetype(String catalog, final String archetype, final String groupId){
 		new DefaultCombo(0).setSelection(catalog);
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
 		new WaitUntil(new TableHasRows(new DefaultTable()),TimePeriod.LONG);
-		// TODO: RedDeer has to be enhanced to find item by text of other rows then just first one
-		new DefaultTable().getItem(archetype,1).select();
+		DefaultTable table = new DefaultTable();
+				 	 	    
+	    @SuppressWarnings("unchecked")
+		List<TableItem> items = table.getItems(new ArtifactIdAndGroupIdMatcher(groupId, archetype));
+	    items.get(0).select();
 	}
 
 }

--- a/maven/test-framework/org.jboss.tools.maven.reddeer/src/org/jboss/tools/maven/reddeer/wizards/matchers/ArtifactIdAndGroupIdMatcher.java
+++ b/maven/test-framework/org.jboss.tools.maven.reddeer/src/org/jboss/tools/maven/reddeer/wizards/matchers/ArtifactIdAndGroupIdMatcher.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.maven.reddeer.wizards.matchers;
+
+import org.eclipse.reddeer.swt.api.TableItem;
+import org.eclipse.reddeer.swt.impl.table.DefaultTableItem;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * This class implements a matcher of groupId and artifactId for 
+ * class org.jboss.tools.maven.reddeer.wizards.MavenProjectWizardSecondPage
+ * 
+ * @author vprusa
+ *
+ */
+public class ArtifactIdAndGroupIdMatcher extends BaseMatcher<TableItem> {
+
+	protected String groupId = null;
+	protected String artifactId = "";
+
+	public ArtifactIdAndGroupIdMatcher(String groupId, String artifactId) {
+		super();
+		this.groupId = groupId;
+		this.artifactId = artifactId;
+	}
+
+	@Override
+	public boolean matches(Object arg0) {
+		DefaultTableItem ti = (DefaultTableItem) arg0;
+		// archetype is necessary, groupId is optional but if set it has to match
+		return ((groupId != null && ti.getText(0).matches(".*" + groupId + ".*")) || groupId == null)
+				&& ti.getText(1).matches(".*" + artifactId + ".*");
+	}
+
+	@Override
+	public void describeTo(Description arg0) {
+	}
+}


### PR DESCRIPTION
Added optional groupId selector for MavenProjectWizardSecondPage to fix failing [tests](https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/maven.itests/jdk=jdk1.8,label=rhel7/479/testReport/org.jboss.tools.maven.ui.bot.test.project/ArchetypesTest/createSimpleJarProjectArchetype_WildFly_11/) in which wrong archetype is selected due to same archetype name but different groupId.