### PR TITLE
JBDS-4730: Use "Red Hat CodeReady Studio" instead of "Red Hat Develop…

### DIFF
--- a/maven/docs/reference/en-US/Book_Info.xml
+++ b/maven/docs/reference/en-US/Book_Info.xml
@@ -7,7 +7,7 @@
     Provides information about the use of <application>Maven</application> within the <application>JBoss Developer Studio</application>.
   </subtitle>
    
-  <productname>Red Hat Developer Studio</productname>
+  <productname>Red Hat CodeReady Studio</productname>
    
   <productnumber>7.1</productnumber>
    


### PR DESCRIPTION
…er Studio" in graphics & text

Signed-off-by: Jeff MAURY <jmaury@redhat.com>