### PR TITLE
Do not use deprecated m2e APIs.

### DIFF
--- a/maven/features/org.jboss.tools.maven.feature/feature.xml
+++ b/maven/features/org.jboss.tools.maven.feature/feature.xml
@@ -2,11 +2,11 @@
 <feature
       id="org.jboss.tools.maven.feature"
       label="%featureName"
-      version="1.9.100.qualifier"
+      version="1.9.200.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.maven.ui"
       license-feature="org.jboss.tools.foundation.license.feature"
-	  license-feature-version="0.0.0">
+      license-feature-version="0.0.0">
 
    <description>
       %description
@@ -23,10 +23,6 @@
    <requires>
       <import feature="org.eclipse.m2e.feature" version="1.5.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2e.wtp.feature" version="1.1.0" match="greaterOrEqual"/>
-
-      <!-- JBIDE-16574 : force m2eclipse-egit to be installed if available
-           Since it's not a real build requirement, we make it optional by tweaking p2.inf
-      -->
       <import feature="org.sonatype.m2e.egit.feature" version="0.14.0" match="greaterOrEqual"/>
    </requires>
 

--- a/maven/features/org.jboss.tools.maven.feature/pom.xml
+++ b/maven/features/org.jboss.tools.maven.feature/pom.xml
@@ -10,5 +10,5 @@
 	<groupId>org.jboss.tools.maven.features</groupId>
 	<artifactId>org.jboss.tools.maven.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.9.100-SNAPSHOT</version>
+	<version>1.9.200-SNAPSHOT</version>
 </project>

--- a/maven/plugins/org.jboss.tools.maven.core/META-INF/MANIFEST.MF
+++ b/maven/plugins/org.jboss.tools.maven.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jboss.tools.maven.core; singleton:=true
-Bundle-Version: 1.9.100.qualifier
+Bundle-Version: 1.9.200.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.jboss.tools.maven.core.MavenCoreActivator
 Require-Bundle: org.eclipse.core.runtime,

--- a/maven/plugins/org.jboss.tools.maven.core/pom.xml
+++ b/maven/plugins/org.jboss.tools.maven.core/pom.xml
@@ -10,5 +10,5 @@
 	<groupId>org.jboss.tools.maven.plugins</groupId>
 	<artifactId>org.jboss.tools.maven.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.9.100-SNAPSHOT</version>
+	<version>1.9.200-SNAPSHOT</version>
 </project>

--- a/maven/plugins/org.jboss.tools.maven.core/src/org/jboss/tools/maven/core/MavenUtil.java
+++ b/maven/plugins/org.jboss.tools.maven.core/src/org/jboss/tools/maven/core/MavenUtil.java
@@ -26,7 +26,6 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -37,7 +36,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.MavenModelManager;
 import org.eclipse.m2e.core.internal.IMavenConstants;
-import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
@@ -229,9 +227,8 @@ public class MavenUtil {
 	public static RepositorySystem getRepositorySystem() {
 		RepositorySystem repositorySystem;
 		try {
-			repositorySystem = MavenPluginActivator.getDefault().getPlexusContainer()
-					.lookup(RepositorySystem.class);
-		} catch (ComponentLookupException e) {
+			repositorySystem = MavenPlugin.getMaven().lookup(RepositorySystem.class);
+		} catch (CoreException e) {
 			throw new RuntimeException(e);
 		}
 		return repositorySystem;

--- a/maven/plugins/org.jboss.tools.maven.core/src/org/jboss/tools/maven/core/internal/resolution/ArtifactResolutionService.java
+++ b/maven/plugins/org.jboss.tools.maven.core/src/org/jboss/tools/maven/core/internal/resolution/ArtifactResolutionService.java
@@ -28,7 +28,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
-import org.eclipse.m2e.core.internal.MavenPluginActivator;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.jboss.tools.maven.core.IArtifactResolutionService;
 import org.jboss.tools.maven.core.MavenCoreActivator;
 import org.jboss.tools.maven.core.MavenUtil;
@@ -163,11 +163,11 @@ public class ArtifactResolutionService implements IArtifactResolutionService {
 	private static ArtifactMetadataSource getArtifactMetadataSource() {
 		ArtifactMetadataSource artifactMetadataSource;
 		try {
-			artifactMetadataSource = MavenPluginActivator.getDefault().getPlexusContainer()
+			artifactMetadataSource = ((MavenImpl)MavenPlugin.getMaven()).getPlexusContainer()
 					.lookup(ArtifactMetadataSource.class, 
 							org.apache.maven.artifact.metadata.ArtifactMetadataSource.class.getName(), 
 							"maven");
-		} catch (ComponentLookupException toughLuck) {
+		} catch (Exception toughLuck) {
 			throw new RuntimeException(toughLuck);
 		}
 		return artifactMetadataSource;


### PR DESCRIPTION
Those APIs are candidate for removal after 6 years of deprecation, and
better and more sustainable alternative should be used.

Signed-off-by: Mickael Istria <mistria@redhat.com>